### PR TITLE
Move yolov5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,5 @@
 	path = src/common/ros2_numpy/ros2_numpy
 	url = https://github.com/Box-Robotics/ros2_numpy.git
 [submodule "src/common/yolov5"]
-	path = src/common/yolov5
+	path = src/perception/vision_pipeline/yolov5
 	url = https://github.com/ultralytics/yolov5.git

--- a/src/perception/vision_pipeline/CMakeLists.txt
+++ b/src/perception/vision_pipeline/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(zed_driver)
+project(vision_pipeline)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/src/perception/vision_pipeline/CMakeLists.txt
+++ b/src/perception/vision_pipeline/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.5)
+project(zed_driver)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+# models folder
+install(DIRECTORY
+  models
+  DESTINATION share/${PROJECT_NAME}
+)
+
+# yolov5 folder
+install(DIRECTORY
+  yolov5
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/perception/vision_pipeline/vision_pipeline/node_detector.py
+++ b/src/perception/vision_pipeline/vision_pipeline/node_detector.py
@@ -1,9 +1,12 @@
+import os
+
 # import ROS2 libraries
 import rclpy
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 from cv_bridge import CvBridge
 import message_filters
+from ament_index_python.packages import get_package_share_directory
 # import ROS2 message libraries
 from sensor_msgs.msg import Image, CameraInfo
 from geometry_msgs.msg import Point
@@ -29,8 +32,8 @@ cv_bridge = CvBridge()
 CAMERA_FOV = 110  # degrees
 
 # loading Pytorch model
-MODEL_PATH = "/home/al-ubuntu20/QUTMS_Driverless/src/perception/vision_pipeline/models/model.pt"
-REPO_PATH = "/home/al-ubuntu20/QUTMS_Driverless/src/common/yolov5"
+MODEL_PATH = os.path.join(get_package_share_directory("vision_pipeline"), "models", "model.pt")
+REPO_PATH = os.path.join(get_package_share_directory("vision_pipeline"), "yolov5")
 CONFIDENCE = 0.40 # higher = tighter filter 
 model = yolov5_init(CONFIDENCE, MODEL_PATH, REPO_PATH)
 


### PR DESCRIPTION
Move yolov5 submodule into the vision_pipeline package and use `get_package_share_directory` to get routes to models and yolov5 without hardcoding path