### PR TITLE
Using deltas in EKF SLAM instead of straight position estimate

### DIFF
--- a/src/navigation/slam/src/ekf_slam/ekf_slam.cpp
+++ b/src/navigation/slam/src/ekf_slam/ekf_slam.cpp
@@ -130,8 +130,14 @@ void EKFslam::position_predict(const Eigen::Matrix<double, CAR_STATE_SIZE, 1>& p
     // since we are taking position directly, no need to run motion models
     // or compute jacobians here
     this->pred_mu.topLeftCorner(CAR_STATE_SIZE, 1) = pred_car_mu;
-
     this->pred_cov.topLeftCorner(CAR_STATE_SIZE, CAR_STATE_SIZE) = pred_car_cov + this->R;
+}
+
+void EKFslam::position_delta_predict(const Eigen::Matrix<double, CAR_STATE_SIZE, 1>& pred_car_mu_delta,
+                                     const Eigen::Matrix<double, CAR_STATE_SIZE, CAR_STATE_SIZE>& pred_car_cov) {
+    this->pred_mu.topLeftCorner(CAR_STATE_SIZE, 1) += pred_car_mu_delta;
+    // 0.1 is arbitrary
+    this->pred_cov.topLeftCorner(CAR_STATE_SIZE, CAR_STATE_SIZE) += 0.1 * pred_car_cov + this->R;
 }
 
 void EKFslam::correct(const std::vector<driverless_msgs::msg::Cone>& detected_cones) {

--- a/src/navigation/slam/src/ekf_slam/ekf_slam.cpp
+++ b/src/navigation/slam/src/ekf_slam/ekf_slam.cpp
@@ -54,7 +54,7 @@ void update_pred_motion_cov(const Eigen::MatrixXd& motion_jacobian,  // G_x
 std::optional<int> find_associated_landmark_idx(const Eigen::MatrixXd& mu, double search_x, double search_y) {
     // data association, uses lowest euclidian distance, within a threshold
 
-    double min_distance = 3 * 3;  // m, threshold^2
+    double min_distance = 2 * 2;  // m, threshold^2
     std::optional<int> idx = {};
 
     for (int i = CAR_STATE_SIZE; i < mu.rows(); i += LANDMARK_STATE_SIZE) {

--- a/src/navigation/slam/src/ekf_slam/ekf_slam.hpp
+++ b/src/navigation/slam/src/ekf_slam/ekf_slam.hpp
@@ -42,6 +42,8 @@ class EKFslam {
     // pred_car_mu is column vector [x, y, theta]^T
     void position_predict(const Eigen::Matrix<double, CAR_STATE_SIZE, 1>& pred_car_mu,
                           const Eigen::Matrix<double, CAR_STATE_SIZE, CAR_STATE_SIZE>& pred_car_cov);
+    void position_delta_predict(const Eigen::Matrix<double, CAR_STATE_SIZE, 1>& pred_car_mu_delta,
+                                const Eigen::Matrix<double, CAR_STATE_SIZE, CAR_STATE_SIZE>& pred_car_cov);
     void correct(const std::vector<driverless_msgs::msg::Cone>& detected_cones);
 
     const Eigen::MatrixXd& get_pred_mu() { return pred_mu; };

--- a/src/navigation/slam/src/ekf_slam/node_ekf_slam.cpp
+++ b/src/navigation/slam/src/ekf_slam/node_ekf_slam.cpp
@@ -53,11 +53,12 @@ class EKFSLAMNode : public rclcpp::Node {
     }
 
     void cone_detection_callback(const driverless_msgs::msg::ConeDetectionStamped::SharedPtr detection_msg) {
-        auto less_than = [detection_msg](geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr pose_msg) {
-            return compute_dt(pose_msg->header.stamp, detection_msg->header.stamp) >= 0;
-        };
+        auto earlier_than_detection =
+            [detection_msg](geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr pose_msg) {
+                return compute_dt(pose_msg->header.stamp, detection_msg->header.stamp) >= 0;
+            };
 
-        auto result = std::find_if(std::rbegin(pose_msgs), std::rend(pose_msgs), less_than);
+        auto result = std::find_if(std::rbegin(pose_msgs), std::rend(pose_msgs), earlier_than_detection);
         if (result == std::rend(pose_msgs)) {
             return;
         }

--- a/src/navigation/slam/src/ekf_slam/node_ekf_slam.cpp
+++ b/src/navigation/slam/src/ekf_slam/node_ekf_slam.cpp
@@ -49,7 +49,6 @@ class EKFSLAMNode : public rclcpp::Node {
 
     void pose_callback(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr pose_msg) {
         this->pose_msgs.push_back(pose_msg);
-        publish_visualisations(pose_msg->header.stamp);
     }
 
     void cone_detection_callback(const driverless_msgs::msg::ConeDetectionStamped::SharedPtr detection_msg) {


### PR DESCRIPTION
Instead of smashing over the top of the pose estimate, we apply the delta the camera has picked up to the state of the EKF, which allows the update step to actually do something.