### PR TITLE
Qos

### DIFF
--- a/src/common/custom_vis/custom_vis/node_matrix_vis.py
+++ b/src/common/custom_vis/custom_vis/node_matrix_vis.py
@@ -12,6 +12,8 @@ from rclpy.node import Node
 
 from driverless_msgs.msg import DoubleMatrix
 
+from driverless_common.common import QOS_ALL
+
 
 def mypause(interval):
     backend = plt.rcParams["backend"]
@@ -33,7 +35,7 @@ class NodeMatrixVisualisation(Node):
     def __init__(self):
         super().__init__("matrix_visualisation")
 
-        self.create_subscription(DoubleMatrix, "matrix", self.matrix_callback, 10)
+        self.create_subscription(DoubleMatrix, "matrix", self.matrix_callback, QOS_ALL)
 
         self.fig, (self.heatmap_ax, self.cbar_ax) = plt.subplots(1, 2, gridspec_kw=dict(width_ratios=[0.9, 0.1]))
         plt.show(block=False)

--- a/src/common/custom_vis/package.xml
+++ b/src/common/custom_vis/package.xml
@@ -9,6 +9,7 @@
 
     <!-- Messages -->
     <depend>driverless_msgs</depend>
+    <depend>driverless_common</depend>
 
     <export>
         <build_type>ament_python</build_type>

--- a/src/common/data_overlay/data_overlay/node_overlay.py
+++ b/src/common/data_overlay/data_overlay/node_overlay.py
@@ -11,6 +11,8 @@ from driverless_msgs.msg import WSSVelocity
 from sensor_msgs.msg import Image, Imu
 from std_msgs.msg import Float32
 
+from driverless_common.common import QOS_ALL
+
 from typing import Optional
 
 cv_bridge = CvBridge()
@@ -48,9 +50,9 @@ class DataOverlay(Node):
         super().__init__("data_overlay_node")
 
         # subscribe to velocity
-        self.create_subscription(WSSVelocity, "/vehicle/wheel_speed", self.velocity_callback, 10)
+        self.create_subscription(WSSVelocity, "/vehicle/wheel_speed", self.velocity_callback, QOS_ALL)
         # subscribe to imu
-        self.create_subscription(Imu, "/imu/data", self.imu_callback, 10)
+        self.create_subscription(Imu, "/imu/data", self.imu_callback, QOS_ALL)
 
         # timer to create frames
         self.create_timer(1 / fps, self.timer_callback)

--- a/src/common/data_overlay/package.xml
+++ b/src/common/data_overlay/package.xml
@@ -10,6 +10,7 @@
     <!-- Messages -->
     <depend>sensor_msgs</depend>
     <depend>std_msgs</depend>
+    <depend>driverless_common</depend>
 
     <exec_depend>ros2launch</exec_depend>
 

--- a/src/common/driverless_common/driverless_common/node_display.py
+++ b/src/common/driverless_common/driverless_common/node_display.py
@@ -6,12 +6,13 @@ from rclpy.node import Node
 from rclpy.publisher import Publisher
 
 from ackermann_msgs.msg import AckermannDriveStamped
-from driverless_msgs.msg import Cone, ConeDetectionStamped, PathStamped
+from driverless_msgs.msg import ConeDetectionStamped, PathStamped
 from geometry_msgs.msg import Point
 from sensor_msgs.msg import Image
 from std_msgs.msg import ColorRGBA
-from visualization_msgs.msg import Marker, MarkerArray
+from visualization_msgs.msg import Marker
 
+from driverless_common.common import QOS_LATEST
 from driverless_common.draw import draw_map, draw_markers, draw_steering
 from driverless_common.marker import path_marker_msg
 
@@ -32,18 +33,18 @@ class DisplayDetections(Node):
         super().__init__("display_node")
 
         # cone detection subscribers
-        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.vision_callback, 1)
-        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.lidar_callback, 1)
+        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.vision_callback, QOS_LATEST)
+        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.lidar_callback, QOS_LATEST)
 
         # track subs
-        self.create_subscription(ConeDetectionStamped, "/slam/global_map", self.slam_callback, 1)
-        self.create_subscription(ConeDetectionStamped, "/slam/local_map", self.local_callback, 1)
+        self.create_subscription(ConeDetectionStamped, "/slam/global_map", self.slam_callback, QOS_LATEST)
+        self.create_subscription(ConeDetectionStamped, "/slam/local_map", self.local_callback, QOS_LATEST)
 
         # steering angle target sub
-        self.create_subscription(AckermannDriveStamped, "/control/driving_command", self.steering_callback, 1)
+        self.create_subscription(AckermannDriveStamped, "/control/driving_command", self.steering_callback, QOS_LATEST)
 
         # path spline sub
-        self.create_subscription(PathStamped, "/planner/path", self.path_callback, 1)
+        self.create_subscription(PathStamped, "/planner/path", self.path_callback, QOS_LATEST)
 
         # cv2 rosboard image pubs
         self.vision_img_publisher: Publisher = self.create_publisher(Image, "/debug_imgs/vision_det_img", 1)

--- a/src/common/driverless_common/driverless_common/node_topic_to_csv.py
+++ b/src/common/driverless_common/driverless_common/node_topic_to_csv.py
@@ -12,6 +12,8 @@ from driverless_msgs.msg import ConeDetectionStamped
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from nav_msgs.msg import Odometry
 
+from driverless_common.common import QOS_ALL
+
 from typing import Any, Dict, List, Tuple
 
 # List of (type, topic)
@@ -49,7 +51,7 @@ class NodeTopicToCSV(Node):
         for type_, topic in SUBSCRIPTIONS:
             self.get_logger().info(f"Subscribing to {topic}")
             callback = lambda x, y=topic: self.msg_callback(x, y)
-            self.create_subscription(type_, topic, callback, 10)
+            self.create_subscription(type_, topic, callback, QOS_ALL)
 
         self.run_begin = dt.datetime.now()
         self.get_logger().info("---Topic to CSV node initalised---")

--- a/src/common/driverless_common/driverless_common/shutdown_node.py
+++ b/src/common/driverless_common/driverless_common/shutdown_node.py
@@ -2,11 +2,13 @@ from rclpy.node import Node
 
 from driverless_msgs.msg import State
 
+from driverless_common.common import QOS_LATEST
+
 
 class ShutdownNode(Node):
     def __init__(self, node_name: str, **kwargs) -> None:
         super().__init__(node_name, **kwargs)
-        self.reset_sub = self.create_subscription(State, "/system/as_status", self.shutdown_callback, 10)
+        self.reset_sub = self.create_subscription(State, "/system/as_status", self.shutdown_callback, QOS_LATEST)
 
     def shutdown_callback(self, msg: State):
         if msg.state in [State.START, State.SELECT_MISSION, State.ACTIVATE_EBS, State.FINISHED, State.EMERGENCY]:

--- a/src/common/driverless_common/include/driverless_common/common.hpp
+++ b/src/common/driverless_common/include/driverless_common/common.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cmath>
+
+#include "rclcpp/qos.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+// See driverless_common/common.py for explanation of how to use these for your scenario.
+const rclcpp::QoS QOS_LATEST(rclcpp::KeepLast(1), rmw_qos_profile_sensor_data);
+const rclcpp::QoS QOS_ALL(rclcpp::KeepLast(100), rmw_qos_profile_parameters);
+
+inline double dist(double x1, double y1, double x2, double y2) {
+    double diff_x = x1 - x2;
+    double diff_y = y1 - y2;
+    return sqrt(diff_x * diff_x + diff_y * diff_y);
+}
+
+inline double fast_dist(double x1, double y1, double x2, double y2) {
+    double diff_x = x1 - x2;
+    double diff_y = y1 - y2;
+    return diff_x * diff_x + diff_y * diff_y;
+}
+
+inline double angle(double x1, double y1, double x2, double y2) {
+    double x_disp = x2 - x1;
+    double y_disp = y2 - y1;
+    return atan2(y_disp, x_disp);
+}
+
+// https://stackoverflow.com/a/29871193
+inline double wrap_to_pi(double x) {
+    double min = x - (-M_PI);
+    double max = M_PI - (-M_PI);
+    return -M_PI + fmod(max + fmod(min, max), max);
+}

--- a/src/control/controllers/controllers/node_point_fitting.py
+++ b/src/control/controllers/controllers/node_point_fitting.py
@@ -13,6 +13,7 @@ from ackermann_msgs.msg import AckermannDriveStamped
 from driverless_msgs.msg import Cone, ConeDetectionStamped
 from sensor_msgs.msg import Image
 
+from driverless_common.common import QOS_LATEST
 from driverless_common.draw import *
 from driverless_common.point import Point, cone_to_point, dist
 from driverless_common.shutdown_node import ShutdownNode
@@ -60,9 +61,9 @@ class BetterReactiveController(Node):
         super().__init__("reactive_traj_controller_node")
 
         # debug image
-        self.create_subscription(Image, "/debug_imgs/vision_det_img", self.img_callback, 1)
+        self.create_subscription(Image, "/debug_imgs/vision_det_img", self.img_callback, QOS_LATEST)
         # cone detections
-        self.create_subscription(ConeDetectionStamped, "/slam/local_map", self.callback, 1)
+        self.create_subscription(ConeDetectionStamped, "/slam/local_map", self.callback, QOS_LATEST)
 
         # publishers
         self.control_publisher: Publisher = self.create_publisher(AckermannDriveStamped, "/control/driving_command", 1)

--- a/src/control/controllers/controllers/node_point_fitting2.py
+++ b/src/control/controllers/controllers/node_point_fitting2.py
@@ -13,6 +13,7 @@ from ackermann_msgs.msg import AckermannDriveStamped
 from driverless_msgs.msg import Cone, ConeDetectionStamped
 from sensor_msgs.msg import Image
 
+from driverless_common.common import QOS_ALL, QOS_LATEST
 from driverless_common.draw import *
 from driverless_common.point import Point
 from driverless_common.shutdown_node import ShutdownNode
@@ -55,9 +56,9 @@ class PointFitController(Node):
         super().__init__("point_fit_controller_node")
 
         # debug image
-        self.create_subscription(Image, "/debug_imgs/lidar_det_img", self.img_callback, 1)
+        self.create_subscription(Image, "/debug_imgs/lidar_det_img", self.img_callback, QOS_LATEST)
         # cone detections
-        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.callback, 1)
+        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.callback, QOS_ALL)
 
         # publishers
         self.control_publisher: Publisher = self.create_publisher(AckermannDriveStamped, "/control/driving_command", 1)

--- a/src/control/controllers/controllers/node_reactive_control.py
+++ b/src/control/controllers/controllers/node_reactive_control.py
@@ -8,6 +8,7 @@ from ackermann_msgs.msg import AckermannDriveStamped
 from driverless_msgs.msg import Cone, ConeDetectionStamped
 from std_msgs.msg import Bool, UInt8
 
+from driverless_common.common import QOS_ALL, QOS_LATEST
 from driverless_common.point import Point, cone_to_point, dist
 from driverless_common.shutdown_node import ShutdownNode
 
@@ -47,13 +48,13 @@ class ReactiveController(Node):
             self.target_accel = 0.0
             self.target_cone_count = 2
             # self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, 1)
-            self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.callback, 1)
+            self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.callback, QOS_ALL)
         else:
             self.Kp_ang = 2.0
             self.target_vel = 1.5  # m/s
             self.target_accel = 0.0
             self.target_cone_count = 2
-            self.create_subscription(ConeDetectionStamped, "/slam/local_map", self.callback, 1)
+            self.create_subscription(ConeDetectionStamped, "/slam/local_map", self.callback, QOS_ALL)
             # self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, 1)
 
         self.control_publisher: Publisher = self.create_publisher(AckermannDriveStamped, "/control/driving_command", 1)

--- a/src/control/controllers/controllers/node_vector_spline.py
+++ b/src/control/controllers/controllers/node_vector_spline.py
@@ -16,9 +16,9 @@ from ackermann_msgs.msg import AckermannDriveStamped
 from driverless_msgs.msg import Cone, ConeDetectionStamped
 from sensor_msgs.msg import Image
 
+from driverless_common.common import QOS_ALL
 from driverless_common.draw import draw_markers, draw_steering, loc_to_img_pt
 from driverless_common.point import Point, cone_to_point, dist
-from driverless_common.shutdown_node import ShutdownNode
 
 from typing import List, Optional, Tuple
 
@@ -29,7 +29,6 @@ blue = Color("blue")
 col_range = list(blue.range_to(red, 100))
 
 Colour = Tuple[int, int, int]
-
 
 ORIGIN = Point(0, 0)
 
@@ -144,7 +143,7 @@ class VectorReactiveController(Node):
             self.in_dist = 2.0
             self.pub_accel = False
 
-            self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, 1)
+            self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, QOS_ALL)
         else:
             self.Kp_ang = -3.0
             self.target_vel = 3.0  # m/s
@@ -152,7 +151,7 @@ class VectorReactiveController(Node):
             self.in_dist = 2.0
             self.pub_accel = False
             # self.create_subscription(ConeDetectionStamped, "/slam/local_map", self.callback, 1)
-            self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, 1)
+            self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, QOS_ALL)
 
         self.control_publisher: Publisher = self.create_publisher(AckermannDriveStamped, "/control/driving_command", 1)
         self.accel_publisher: Publisher = self.create_publisher(AckermannDriveStamped, "/control/accel_command", 1)

--- a/src/control/path_follower/path_follower/__init__.py
+++ b/src/control/path_follower/path_follower/__init__.py
@@ -1,8 +1,0 @@
-from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
-
-qos_profile = QoSProfile(
-    reliability=QoSReliabilityPolicy.BEST_EFFORT,
-    history=QoSHistoryPolicy.KEEP_LAST,
-    depth=1,
-    durability=QoSDurabilityPolicy.VOLATILE,
-)

--- a/src/control/path_follower/path_follower/node_pure_pursuit.py
+++ b/src/control/path_follower/path_follower/node_pure_pursuit.py
@@ -16,9 +16,7 @@ from geometry_msgs.msg import PoseWithCovarianceStamped
 from sensor_msgs.msg import Image
 from std_msgs.msg import Bool, UInt8
 
-from driverless_common.common import angle, dist, fast_dist, wrap_to_pi
-
-from . import qos_profile
+from driverless_common.common import QOS_LATEST, angle, dist, fast_dist, wrap_to_pi
 
 from typing import List
 
@@ -56,11 +54,11 @@ class PurePursuit(Node):
         super().__init__("pure_pursuit_node")
 
         # subscribers
-        self.create_subscription(Bool, "/system/r2d", self.r2d_callback, 10)
-        self.create_subscription(UInt8, "/system/laps_completed", self.lap_callback, 10)
-        self.create_subscription(PathStamped, "/planner/path", self.path_callback, 10)
+        self.create_subscription(Bool, "/system/r2d", self.r2d_callback, QOS_LATEST)
+        self.create_subscription(UInt8, "/system/laps_completed", self.lap_callback, QOS_LATEST)
+        self.create_subscription(PathStamped, "/planner/path", self.path_callback, QOS_LATEST)
         # sync subscribers pose + velocity
-        self.create_subscription(PoseWithCovarianceStamped, "/slam/car_pose", self.callback, qos_profile=qos_profile)
+        self.create_subscription(PoseWithCovarianceStamped, "/slam/car_pose", self.callback, QOS_LATEST)
 
         # publishers
         self.control_publisher: Publisher = self.create_publisher(AckermannDriveStamped, "/control/driving_command", 10)

--- a/src/control/path_follower/path_follower/node_pure_pursuit_kdtree.py
+++ b/src/control/path_follower/path_follower/node_pure_pursuit_kdtree.py
@@ -15,7 +15,7 @@ from driverless_msgs.msg import PathStamped
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from sensor_msgs.msg import Image
 
-from driverless_common.common import angle, dist, wrap_to_pi
+from driverless_common.common import QOS_LATEST, angle, dist, wrap_to_pi
 
 from . import qos_profile
 
@@ -48,9 +48,9 @@ class FastPurePursuit(Node):
     def __init__(self):
         super().__init__("fast_pure_pursuit_node")
 
-        self.create_subscription(PathStamped, "/planner/path", self.path_callback, qos_profile=qos_profile)
+        self.create_subscription(PathStamped, "/planner/path", self.path_callback, QOS_LATEST)
         # sync subscribers pose + velocity
-        self.create_subscription(PoseWithCovarianceStamped, "/slam/car_pose", self.callback, qos_profile=qos_profile)
+        self.create_subscription(PoseWithCovarianceStamped, "/slam/car_pose", self.callback, QOS_LATEST)
 
         # publishers
         self.control_publisher: Publisher = self.create_publisher(AckermannDriveStamped, "/control/driving_command", 10)

--- a/src/control/pure_pursuit_cpp/CMakeLists.txt
+++ b/src/control/pure_pursuit_cpp/CMakeLists.txt
@@ -12,17 +12,17 @@ find_package(ackermann_msgs REQUIRED)
 find_package(driverless_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 
-include_directories(include)
-
 SET_SOURCE_FILES_PROPERTIES(${SOURCES} PROPERTIES LANGUAGE CXX)
 
 add_executable(pure_pursuit_cpp src/node_pure_pursuit_cpp.cpp ${SOURCES})
+target_include_directories(pure_pursuit_cpp
+        PUBLIC include
+        PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
 ament_target_dependencies(pure_pursuit_cpp
         rclcpp
         driverless_msgs
         ackermann_msgs
-        tf2
-        )
+        tf2)
 
 target_include_directories(pure_pursuit_cpp PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/control/steering_testing/steering_testing/node_step_response_calibration.py
+++ b/src/control/steering_testing/steering_testing/node_step_response_calibration.py
@@ -15,7 +15,7 @@ from driverless_msgs.msg import SteeringReading
 from sensor_msgs.msg import Image
 from std_msgs.msg import Int32
 
-from driverless_common.shutdown_node import ShutdownNode
+from driverless_common.common import QOS_LATEST
 
 
 class StepController(Node):
@@ -40,8 +40,8 @@ class StepController(Node):
         self.create_timer(self.change_interval, self.change_callback)
         self.create_timer(self.pub_interval, self.pub_callback)
 
-        self.create_subscription(SteeringReading, "/vehicle/steering_reading", self.sub_callback_st, 1)
-        self.create_subscription(Int32, "/vehicle/encoder_reading", self.sub_callback_en, 1)
+        self.create_subscription(SteeringReading, "/vehicle/steering_reading", self.sub_callback_st, QOS_LATEST)
+        self.create_subscription(Int32, "/vehicle/encoder_reading", self.sub_callback_en, QOS_LATEST)
 
         self.drive_publisher: Publisher = self.create_publisher(AckermannDriveStamped, "/control/driving_command", 1)
         self.model_img_publisher: Publisher = self.create_publisher(Image, "/debug_imgs/model_calibration_image", 1)

--- a/src/control/yaw_controller/CMakeLists.txt
+++ b/src/control/yaw_controller/CMakeLists.txt
@@ -13,11 +13,12 @@ find_package(driverless_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 
-include_directories(include)
-
 SET_SOURCE_FILES_PROPERTIES(${SOURCES} PROPERTIES LANGUAGE CXX )
 
 add_executable(yaw_controller src/node_yaw_controller.cpp ${SOURCES})
+target_include_directories(yaw_controller
+        PUBLIC include
+        PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
 ament_target_dependencies(yaw_controller
     rclcpp
     driverless_msgs

--- a/src/control/yaw_controller/src/node_yaw_controller.cpp
+++ b/src/control/yaw_controller/src/node_yaw_controller.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include "ackermann_msgs/msg/ackermann_drive_stamped.hpp"
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/state.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -123,11 +124,11 @@ class YawController : public rclcpp::Node {
         this->update_parameters(rcl_interfaces::msg::ParameterEvent());
 
         this->shutdown_sub = this->create_subscription<driverless_msgs::msg::State>(
-            "/system/as_status", 10, std::bind(&YawController::shutdown_callback, this, _1));
+            "/system/as_status", QOS_LATEST, std::bind(&YawController::shutdown_callback, this, _1));
         this->velocity_sub = this->create_subscription<geometry_msgs::msg::TwistStamped>(
-            "imu/velocity", 10, std::bind(&YawController::velocity_callback, this, _1));
+            "imu/velocity", QOS_LATEST, std::bind(&YawController::velocity_callback, this, _1));
         this->imu_sub = this->create_subscription<sensor_msgs::msg::Imu>(
-            "imu/data", 10, std::bind(&YawController::imu_callback, this, _1));
+            "imu/data", QOS_LATEST, std::bind(&YawController::imu_callback, this, _1));
         this->yaw_timer =
             this->create_wall_timer(std::chrono::milliseconds(100), std::bind(&YawController::yaw_callback, this));
         this->yaw_rate_timer =

--- a/src/hardware/canbus/CMakeLists.txt
+++ b/src/hardware/canbus/CMakeLists.txt
@@ -12,8 +12,6 @@ find_package(ament_cmake REQUIRED)
 find_package(driverless_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 
-include_directories(include)
-
 set (SOURCES
   src/can2ethernet_adapter.cpp
   src/tcp_client.cpp
@@ -23,7 +21,7 @@ set (SOURCES
 
 add_executable(canbus_translator_node src/node_canbus.cpp ${SOURCES})
 ament_target_dependencies(canbus_translator_node rclcpp driverless_msgs)
-
+target_include_directories(canbus_translator_node PUBLIC include PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
 target_include_directories(canbus_translator_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/src/hardware/canbus/src/node_canbus.cpp
+++ b/src/hardware/canbus/src/node_canbus.cpp
@@ -4,6 +4,7 @@
 
 #include "TritiumCAN.hpp"
 //#include "can2etherenet_adapter.hpp"
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/can.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -75,7 +76,7 @@ class CanBus : public rclcpp::Node {
         this->declare_parameter<int>("port", 0);
 
         this->subscription_ = this->create_subscription<driverless_msgs::msg::Can>(
-            "/can/canbus_carbound", 10, std::bind(&CanBus::canmsg_callback, this, _1));
+            "/can/canbus_carbound", QOS_ALL, std::bind(&CanBus::canmsg_callback, this, _1));
 
         this->publisher_ = this->create_publisher<driverless_msgs::msg::Can>("/can/canbus_rosbound", 10);
 

--- a/src/hardware/car_status/CMakeLists.txt
+++ b/src/hardware/car_status/CMakeLists.txt
@@ -28,7 +28,7 @@ SET_SOURCE_FILES_PROPERTIES(${SOURCES} PROPERTIES LANGUAGE CXX )
 
 add_executable(car_status_node src/node_car_status.cpp ${SOURCES})
 ament_target_dependencies(car_status_node rclcpp driverless_msgs)
-
+target_include_directories(car_status_node PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
 target_include_directories(car_status_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/src/hardware/car_status/src/node_car_status.cpp
+++ b/src/hardware/car_status/src/node_car_status.cpp
@@ -2,6 +2,7 @@
 
 #include "CAN_BMU.h"
 #include "can_interface.hpp"
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/car_status.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -49,7 +50,7 @@ class CarStatusNode : public rclcpp::Node, public CanInterface {
    public:
     CarStatusNode() : Node("bmu_status_node") {
         this->can_sub = this->create_subscription<driverless_msgs::msg::Can>(
-            "/can/canbus_rosbound", 10, std::bind(&CarStatusNode::canbus_callback, this, _1));
+            "/can/canbus_rosbound", QOS_ALL, std::bind(&CarStatusNode::canbus_callback, this, _1));
         this->car_status_pub = this->create_publisher<driverless_msgs::msg::CarStatus>("/vehicle/bmu_status", 10);
 
         this->car_status.brick_data = std::vector<driverless_msgs::msg::BrickData>(NUM_CMUS);

--- a/src/hardware/sbg_testing/package.xml
+++ b/src/hardware/sbg_testing/package.xml
@@ -13,6 +13,7 @@
     <!-- Messages -->
     <depend>geometry_msgs</depend>
     <depend>sensor_msgs</depend>
+    <depend>driverless_common</depend>
 
     <export>
         <build_type>ament_python</build_type>

--- a/src/hardware/sbg_testing/sbg_testing/node_sbg_debug.py
+++ b/src/hardware/sbg_testing/sbg_testing/node_sbg_debug.py
@@ -14,6 +14,8 @@ from geometry_msgs.msg import Point, PointStamped, PoseWithCovarianceStamped, Qu
 from sbg_driver.msg import SbgEkfEuler, SbgEkfNav, SbgGpsPos, SbgGpsVel, SbgImuData, SbgMag
 from sensor_msgs.msg import Imu, NavSatFix
 
+from driverless_common.common import QOS_LATEST
+
 
 class SBGDebug(Node):
     def __init__(self):
@@ -50,11 +52,11 @@ class SBGDebug(Node):
         )
 
         # sbg & imu data visualisation subscribers
-        self.create_subscription(SbgGpsPos, "/sbg/gps_pos", self.sbg_gps_pos_callback, 1)
-        self.create_subscription(SbgGpsVel, "/sbg/gps_vel", self.sbg_gps_vel_callback, 1)
-        self.create_subscription(SbgMag, "/sbg/mag", self.sbg_mag_callback, 1)
-        self.create_subscription(Imu, "/imu/data", self.imu_data_callback, 1)
-        self.create_subscription(SbgImuData, "/sbg/imu_data", self.sbg_imu_data_callback, 1)
+        self.create_subscription(SbgGpsPos, "/sbg/gps_pos", self.sbg_gps_pos_callback, QOS_LATEST)
+        self.create_subscription(SbgGpsVel, "/sbg/gps_vel", self.sbg_gps_vel_callback, QOS_LATEST)
+        self.create_subscription(SbgMag, "/sbg/mag", self.sbg_mag_callback, QOS_LATEST)
+        self.create_subscription(Imu, "/imu/data", self.imu_data_callback, QOS_LATEST)
+        self.create_subscription(SbgImuData, "/sbg/imu_data", self.sbg_imu_data_callback, QOS_LATEST)
 
         # sbg gps pos visualisation publishers
         self.sbg_gps_pos_coords_point_publisher: Publisher = self.create_publisher(

--- a/src/hardware/sbg_testing/sbg_testing/node_sbg_performance.py
+++ b/src/hardware/sbg_testing/sbg_testing/node_sbg_performance.py
@@ -1,24 +1,19 @@
-from collections import OrderedDict
-import csv
-import datetime as dt
-from datetime import datetime
-from math import atan2, cos, hypot, pi, sin, sqrt
-from pathlib import Path
+from math import cos, pi, sin, sqrt
 import time
 
-import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 import numpy as np
 
 import rclpy
 from rclpy.node import Node
-from rosidl_runtime_py.convert import message_to_ordereddict
 
 from geometry_msgs.msg import TwistStamped
 from sbg_driver.msg import SbgEkfNav
-from sensor_msgs.msg import Imu, NavSatFix
+from sensor_msgs.msg import NavSatFix
 
-from typing import Any, Dict, List, Optional, Tuple
+from driverless_common.common import QOS_ALL
+
+from typing import List, Optional
 
 
 class VelocityManager:
@@ -105,13 +100,13 @@ class SbgPerformance(Node):
         super().__init__("sbg_performance")
 
         self.vel_manager = VelocityManager()
-        self.create_subscription(TwistStamped, "imu/velocity", self.vel_manager.velocity_callback, 10)
+        self.create_subscription(TwistStamped, "imu/velocity", self.vel_manager.velocity_callback, QOS_ALL)
 
         self.ekf_nav_manager = EkfNavManager()
-        self.create_subscription(SbgEkfNav, "sbg/ekf_nav", self.ekf_nav_manager.ekf_nav_callback, 10)
+        self.create_subscription(SbgEkfNav, "sbg/ekf_nav", self.ekf_nav_manager.ekf_nav_callback, QOS_ALL)
 
         self.nav_sat_fix_manager = NavSatFixManager()
-        self.create_subscription(NavSatFix, "imu/nav_sat_fix", self.nav_sat_fix_manager.nav_sat_fix_callback, 10)
+        self.create_subscription(NavSatFix, "imu/nav_sat_fix", self.nav_sat_fix_manager.nav_sat_fix_callback, QOS_ALL)
 
         timer_period = 1  # seconds
         self.timer = self.create_timer(timer_period, self.update_graph)

--- a/src/hardware/steering_actuator/CMakeLists.txt
+++ b/src/hardware/steering_actuator/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rclcpp REQUIRED)
 
 include_directories(include)
 include_directories(${CMAKE_SOURCE_DIR}/../../hardware/CAN_Common/include/)
+include_directories(${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
 
 set (SOURCES
   ${CMAKE_SOURCE_DIR}/../../hardware/CAN_Common/src/canopen.cpp
@@ -28,7 +29,6 @@ add_executable(steering_can_pulse_node src/node_steering_CAN_pulse.cpp ${SOURCES
 ament_target_dependencies(steering_actuator_node rclcpp ackermann_msgs driverless_msgs std_msgs)
 ament_target_dependencies(steering_actuator_node_old rclcpp ackermann_msgs driverless_msgs std_msgs)
 ament_target_dependencies(steering_can_pulse_node rclcpp ackermann_msgs driverless_msgs std_msgs)
-
 target_include_directories(steering_actuator_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/src/hardware/steering_actuator/src/node_steering_CAN_pulse.cpp
+++ b/src/hardware/steering_actuator/src/node_steering_CAN_pulse.cpp
@@ -3,6 +3,7 @@
 
 #include "can_interface.hpp"  // CAN interface library to convert data array into a canbus frame (data_2_frame)
 #include "canopen.hpp"        // CAN library to communicate systems via sdo_read and sdo_write
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/can.hpp"  // ROS Messages
 #include "driverless_msgs/msg/state.hpp"
 #include "driverless_msgs/msg/steering_reading.hpp"
@@ -275,7 +276,7 @@ class SteeringActuator : public rclcpp::Node, public CanInterface {
 
         // Create subscriber to topic "canbus_rosbound"
         this->can_sub = this->create_subscription<driverless_msgs::msg::Can>(
-            "/can/canbus_rosbound", 10, std::bind(&SteeringActuator::can_callback, this, _1));
+            "/can/canbus_rosbound", QOS_ALL, std::bind(&SteeringActuator::can_callback, this, _1));
 
         // Create state request and config timers
         this->c5e_state_request_timer = this->create_wall_timer(

--- a/src/hardware/steering_actuator/src/node_steering_actuator.cpp
+++ b/src/hardware/steering_actuator/src/node_steering_actuator.cpp
@@ -4,6 +4,7 @@
 #include "ackermann_msgs/msg/ackermann_drive_stamped.hpp"  // ROS Messages
 #include "can_interface.hpp"  // CAN interface library to convert data array into a canbus frame (data_2_frame)
 #include "canopen.hpp"        // CAN library to communicate systems via sdo_read and sdo_write
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/can.hpp"  // ROS Messages
 #include "driverless_msgs/msg/state.hpp"
 #include "rclcpp/rclcpp.hpp"  // C++ Required Libraries
@@ -559,19 +560,19 @@ class SteeringActuator : public rclcpp::Node, public CanInterface {
 
         // Create subscriber to topic AS status
         this->state_sub = this->create_subscription<driverless_msgs::msg::State>(
-            "/system/as_status", 10, std::bind(&SteeringActuator::as_state_callback, this, _1));
+            "/system/as_status", QOS_ALL, std::bind(&SteeringActuator::as_state_callback, this, _1));
 
         // Create subscriber to topic "steering_angle"
         this->steer_ang_sub = this->create_subscription<std_msgs::msg::Float32>(
-            "/vehicle/steering_angle", 10, std::bind(&SteeringActuator::steering_angle_callback, this, _1));
+            "/vehicle/steering_angle", QOS_ALL, std::bind(&SteeringActuator::steering_angle_callback, this, _1));
 
         // Create subscriber to topic "driving_command"
         this->ackermann_sub = this->create_subscription<ackermann_msgs::msg::AckermannDriveStamped>(
-            "/control/driving_command", 10, std::bind(&SteeringActuator::driving_command_callback, this, _1));
+            "/control/driving_command", QOS_ALL, std::bind(&SteeringActuator::driving_command_callback, this, _1));
 
         // Create subscriber to topic "canbus_rosbound"
         this->can_sub = this->create_subscription<driverless_msgs::msg::Can>(
-            "/can/canbus_rosbound", 10, std::bind(&SteeringActuator::can_callback, this, _1));
+            "/can/canbus_rosbound", QOS_ALL, std::bind(&SteeringActuator::can_callback, this, _1));
 
         // Create state request and config timers
         this->steering_update_timer =

--- a/src/hardware/steering_actuator/src/node_steering_actuator_adj.cpp
+++ b/src/hardware/steering_actuator/src/node_steering_actuator_adj.cpp
@@ -4,6 +4,7 @@
 #include "ackermann_msgs/msg/ackermann_drive_stamped.hpp"  // ROS Messages
 #include "can_interface.hpp"  // CAN interface library to convert data array into a canbus frame (data_2_frame)
 #include "canopen.hpp"        // CAN library to communicate systems via sdo_read and sdo_write
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/can.hpp"  // ROS Messages
 #include "driverless_msgs/msg/state.hpp"
 #include "rclcpp/rclcpp.hpp"  // C++ Required Libraries
@@ -495,19 +496,19 @@ class SteeringActuator : public rclcpp::Node, public CanInterface {
 
         // Create subscriber to topic AS status
         this->state_sub = this->create_subscription<driverless_msgs::msg::State>(
-            "/system/as_status", 10, std::bind(&SteeringActuator::as_state_callback, this, _1));
+            "/system/as_status", QOS_LATEST, std::bind(&SteeringActuator::as_state_callback, this, _1));
 
         // Create subscriber to topic "steering_angle"
         this->steer_ang_sub = this->create_subscription<std_msgs::msg::Float32>(
-            "/vehicle/steering_angle", 10, std::bind(&SteeringActuator::steering_angle_callback, this, _1));
+            "/vehicle/steering_angle", QOS_ALL, std::bind(&SteeringActuator::steering_angle_callback, this, _1));
 
         // Create subscriber to topic "driving_command"
         this->ackermann_sub = this->create_subscription<ackermann_msgs::msg::AckermannDriveStamped>(
-            "/control/driving_command", 10, std::bind(&SteeringActuator::driving_command_callback, this, _1));
+            "/control/driving_command", QOS_ALL, std::bind(&SteeringActuator::driving_command_callback, this, _1));
 
         // Create subscriber to topic "canbus_rosbound"
         this->can_sub = this->create_subscription<driverless_msgs::msg::Can>(
-            "/can/canbus_rosbound", 10, std::bind(&SteeringActuator::can_callback, this, _1));
+            "/can/canbus_rosbound", QOS_ALL, std::bind(&SteeringActuator::can_callback, this, _1));
 
         // Create state request and config timers
         this->steering_update_timer =

--- a/src/hardware/steering_actuator/src/node_steering_actuator_old.cpp
+++ b/src/hardware/steering_actuator/src/node_steering_actuator_old.cpp
@@ -4,6 +4,7 @@
 #include "ackermann_msgs/msg/ackermann_drive_stamped.hpp"  // ROS Messages
 #include "can_interface.hpp"  // CAN interface library to convert data array into a canbus frame (data_2_frame)
 #include "canopen.hpp"        // CAN library to communicate systems via sdo_read and sdo_write
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/can.hpp"  // ROS Messages
 #include "driverless_msgs/msg/state.hpp"
 #include "driverless_msgs/msg/steering_reading.hpp"
@@ -473,19 +474,19 @@ class SteeringActuator : public rclcpp::Node, public CanInterface {
 
         // Create subscriber to topic "as_status"
         this->state_sub = this->create_subscription<driverless_msgs::msg::State>(
-            "/system/as_status", 10, std::bind(&SteeringActuator::as_state_callback, this, _1));
+            "/system/as_status", QOS_LATEST, std::bind(&SteeringActuator::as_state_callback, this, _1));
 
         // Create subscriber to topic "steering_reading"
         this->steering_reading_sub = this->create_subscription<driverless_msgs::msg::SteeringReading>(
-            "/vehicle/steering_reading", 10, std::bind(&SteeringActuator::steering_reading_callback, this, _1));
+            "/vehicle/steering_reading", QOS_ALL, std::bind(&SteeringActuator::steering_reading_callback, this, _1));
 
         // Create subscriber to topic "driving_command"
         this->ackermann_sub = this->create_subscription<ackermann_msgs::msg::AckermannDriveStamped>(
-            "/control/driving_command", 10, std::bind(&SteeringActuator::driving_command_callback, this, _1));
+            "/control/driving_command", QOS_ALL, std::bind(&SteeringActuator::driving_command_callback, this, _1));
 
         // Create subscriber to topic "canbus_rosbound"
         this->can_sub = this->create_subscription<driverless_msgs::msg::Can>(
-            "/can/canbus_rosbound", 10, std::bind(&SteeringActuator::can_callback, this, _1));
+            "/can/canbus_rosbound", QOS_ALL, std::bind(&SteeringActuator::can_callback, this, _1));
 
         // Create state request and config timers
         this->c5e_state_request_timer = this->create_wall_timer(

--- a/src/hardware/vehicle_supervisor/CMakeLists.txt
+++ b/src/hardware/vehicle_supervisor/CMakeLists.txt
@@ -39,7 +39,7 @@ SET_SOURCE_FILES_PROPERTIES(${SOURCES} PROPERTIES LANGUAGE CXX )
 
 add_executable(vehicle_supervisor_node src/node_supervisor.cpp ${SOURCES})
 ament_target_dependencies(vehicle_supervisor_node rclcpp driverless_msgs ackermann_msgs std_msgs nav_msgs)
-
+target_include_directories(vehicle_supervisor_node PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
 target_include_directories(vehicle_supervisor_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/src/hardware/vehicle_supervisor/src/node_supervisor.cpp
+++ b/src/hardware/vehicle_supervisor/src/node_supervisor.cpp
@@ -8,6 +8,7 @@
 #include "QUTMS_can.h"
 #include "ackermann_msgs/msg/ackermann_drive_stamped.hpp"
 #include "can_interface.hpp"
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/can.hpp"
 #include "driverless_msgs/msg/driving_dynamics1.hpp"
 #include "driverless_msgs/msg/motor_rpm.hpp"
@@ -565,14 +566,14 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
         // CAN
         this->can_pub = this->create_publisher<driverless_msgs::msg::Can>("/can/canbus_carbound", 10);
         this->can_sub = this->create_subscription<driverless_msgs::msg::Can>(
-            "/can/canbus_rosbound", 10, std::bind(&ASSupervisor::canbus_callback, this, _1));
+            "/can/canbus_rosbound", QOS_ALL, std::bind(&ASSupervisor::canbus_callback, this, _1));
 
         // State
         this->state_pub = this->create_publisher<driverless_msgs::msg::State>("/system/as_status", 10);
 
         // Mission select
         this->mission_select_sub = this->create_subscription<std_msgs::msg::UInt8>(
-            "/system/mission_select", 10, std::bind(&ASSupervisor::mission_select_callback, this, _1));
+            "/system/mission_select", QOS_ALL, std::bind(&ASSupervisor::mission_select_callback, this, _1));
 
         // Reset
         this->reset_pub = this->create_publisher<driverless_msgs::msg::Reset>("/system/reset", 10);
@@ -592,7 +593,7 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
 
         // Ackermann -> sub to acceleration command
         this->ackermann_sub = this->create_subscription<ackermann_msgs::msg::AckermannDriveStamped>(
-            "/control/accel_command", 10, std::bind(&ASSupervisor::ackermann_callback, this, _1));
+            "/control/accel_command", QOS_ALL, std::bind(&ASSupervisor::ackermann_callback, this, _1));
 
         // Heartbeat
         this->heartbeat_timer =
@@ -612,7 +613,7 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
 
         // Shutdown emergency
         this->shutdown_sub = this->create_subscription<driverless_msgs::msg::Shutdown>(
-            "/system/shutdown", 10, std::bind(&ASSupervisor::shutdown_callback, this, _1));
+            "/system/shutdown", QOS_LATEST, std::bind(&ASSupervisor::shutdown_callback, this, _1));
         RCLCPP_INFO(this->get_logger(), "---Vehicle Supervisor Node Initialised---");
     }
 };

--- a/src/hardware/velocity_controller/CMakeLists.txt
+++ b/src/hardware/velocity_controller/CMakeLists.txt
@@ -19,7 +19,7 @@ SET_SOURCE_FILES_PROPERTIES(${SOURCES} PROPERTIES LANGUAGE CXX )
 
 add_executable(velocity_controller_node src/node_velocity_controller.cpp ${SOURCES})
 ament_target_dependencies(velocity_controller_node rclcpp driverless_msgs ackermann_msgs)
-
+target_include_directories(velocity_controller_node PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
 target_include_directories(velocity_controller_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/src/hardware/velocity_controller/src/node_velocity_controller.cpp
+++ b/src/hardware/velocity_controller/src/node_velocity_controller.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 
 #include "ackermann_msgs/msg/ackermann_drive_stamped.hpp"
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/motor_rpm.hpp"
 #include "driverless_msgs/msg/state.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
@@ -152,15 +153,15 @@ class Velocity_Controller : public rclcpp::Node {
 
         // State updates
         this->state_sub = this->create_subscription<driverless_msgs::msg::State>(
-            "/system/as_status", 10, std::bind(&Velocity_Controller::as_state_callback, this, _1));
+            "/system/as_status", QOS_LATEST, std::bind(&Velocity_Controller::as_state_callback, this, _1));
 
         // Ackermann
         this->ackermann_sub = this->create_subscription<ackermann_msgs::msg::AckermannDriveStamped>(
-            "/control/driving_command", 10, std::bind(&Velocity_Controller::ackermann_callback, this, _1));
+            "/control/driving_command", QOS_ALL, std::bind(&Velocity_Controller::ackermann_callback, this, _1));
 
         // Velocity updates
         this->motorRPM_sub = this->create_subscription<driverless_msgs::msg::MotorRPM>(
-            "/vehicle/motor_rpm", 10, std::bind(&Velocity_Controller::rpm_callback, this, _1));
+            "/vehicle/motor_rpm", QOS_ALL, std::bind(&Velocity_Controller::rpm_callback, this, _1));
 
         // Control loop -> 10ms so runs at double speed heartbeats are sent at
         this->controller_timer = this->create_wall_timer(std::chrono::milliseconds(10),

--- a/src/navigation/planners/planners/node_delaunay_planner.py
+++ b/src/navigation/planners/planners/node_delaunay_planner.py
@@ -18,8 +18,8 @@ from sensor_msgs.msg import Image
 from std_msgs.msg import ColorRGBA
 from visualization_msgs.msg import Marker
 
+from driverless_common.common import QOS_LATEST
 from driverless_common.marker import delaunay_marker_msg
-from driverless_common.shutdown_node import ShutdownNode
 
 from typing import List, Tuple
 
@@ -150,7 +150,7 @@ class TrackPlanner(Node):
         super().__init__("global_planner_node")
 
         # sub to track for all cone locations relative to car start point
-        self.create_subscription(TrackDetectionStamped, "/slam/global_map", self.callback, 10)
+        self.create_subscription(TrackDetectionStamped, "/slam/global_map", self.callback, QOS_LATEST)
 
         # publishers
         self.path_publisher: Publisher = self.create_publisher(PathStamped, "/planner/path", 1)

--- a/src/navigation/planners/planners/node_ordered_mid_spline.py
+++ b/src/navigation/planners/planners/node_ordered_mid_spline.py
@@ -14,7 +14,7 @@ from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Path
 from std_msgs.msg import UInt8
 
-from driverless_common.common import angle, midpoint
+from driverless_common.common import QOS_LATEST, angle, midpoint
 
 from typing import List, Tuple
 
@@ -128,8 +128,8 @@ class OrderedMapSpline(Node):
         super().__init__("ordered_map_spline_node")
 
         # sub to track for all cone locations relative to car start point
-        self.create_subscription(ConeDetectionStamped, "/slam/global_map", self.map_callback, 10)
-        self.create_subscription(UInt8, "/system/laps_completed", self.lap_callback, 10)
+        self.create_subscription(ConeDetectionStamped, "/slam/global_map", self.map_callback, QOS_LATEST)
+        self.create_subscription(UInt8, "/system/laps_completed", self.lap_callback, QOS_LATEST)
         self.create_timer(0.1, self.planning_callback)
 
         # publishers

--- a/src/navigation/py_slam/package.xml
+++ b/src/navigation/py_slam/package.xml
@@ -15,6 +15,7 @@
     <depend>sensor_msgs</depend>
     <depend>nav_msgs</depend>
     <depend>geodesy</depend>
+    <depend>driverless_common</depend>
 
     <export>
         <build_type>ament_python</build_type>

--- a/src/navigation/py_slam/py_slam/node_imu_slam.py
+++ b/src/navigation/py_slam/py_slam/node_imu_slam.py
@@ -14,6 +14,7 @@ from rclpy.publisher import Publisher
 from driverless_msgs.msg import ConeDetectionStamped, ConeWithCovariance, Reset
 from geometry_msgs.msg import Point, PoseStamped, PoseWithCovarianceStamped, Quaternion, TransformStamped, TwistStamped
 
+from driverless_common.common import QOS_ALL, QOS_LATEST
 from py_slam.cone_props import ConeProps
 
 from typing import Optional
@@ -56,8 +57,8 @@ class IMUSlam(Node):
         )
         lidar_synchronizer.registerCallback(self.sync_callback)
 
-        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, 1)
-        self.create_subscription(Reset, "/system/reset", self.reset_callback, 10)
+        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, QOS_ALL)
+        self.create_subscription(Reset, "/system/reset", self.reset_callback, QOS_LATEST)
 
         # slam publisher
         self.slam_publisher: Publisher = self.create_publisher(ConeDetectionStamped, "/slam/global_map", 1)

--- a/src/navigation/py_slam/py_slam/node_odom_slam.py
+++ b/src/navigation/py_slam/py_slam/node_odom_slam.py
@@ -17,7 +17,7 @@ from rclpy.publisher import Publisher
 from driverless_msgs.msg import ConeDetectionStamped, ConeWithCovariance, Reset
 from geometry_msgs.msg import Point, PoseStamped, PoseWithCovarianceStamped, Quaternion, TransformStamped
 
-from driverless_common.common import wrap_to_pi
+from driverless_common.common import QOS_ALL, QOS_LATEST, wrap_to_pi
 from py_slam.cone_props import ConeProps
 
 from typing import Optional, Tuple
@@ -46,9 +46,9 @@ class OdomSlam(Node):
 
         self.create_timer((1 / 50), self.timer_callback)  # 50hz state 'prediction'
 
-        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.callback, 1)
-        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, 1)
-        self.create_subscription(Reset, "/system/reset", self.reset_callback, 10)
+        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.callback, QOS_ALL)
+        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, QOS_ALL)
+        self.create_subscription(Reset, "/system/reset", self.reset_callback, QOS_LATEST)
 
         self.tf_buffer = Buffer()
         self.tf_listener = TransformListener(self.tf_buffer, self)

--- a/src/navigation/py_slam/py_slam/node_sbg_slam.py
+++ b/src/navigation/py_slam/py_slam/node_sbg_slam.py
@@ -16,6 +16,7 @@ from driverless_msgs.msg import ConeDetectionStamped, ConeWithCovariance, Reset,
 from geometry_msgs.msg import Point, PoseStamped, PoseWithCovarianceStamped, Quaternion, TransformStamped
 from sbg_driver.msg import SbgEkfEuler, SbgEkfNav, SbgGpsPos
 
+from driverless_common.common import QOS_ALL, QOS_LATEST
 from py_slam.cone_props import ConeProps
 
 from typing import Optional, Tuple
@@ -53,9 +54,9 @@ class SBGSlam(Node):
         ins_synchronizer = message_filters.ApproximateTimeSynchronizer(fs=[pos_sub, ang_sub], queue_size=20, slop=0.2)
         ins_synchronizer.registerCallback(self.ins_callback)
 
-        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.callback, 1)
-        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, 1)
-        self.create_subscription(Reset, "/system/reset", self.reset_callback, 10)
+        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.callback, QOS_ALL)
+        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, QOS_ALL)
+        self.create_subscription(Reset, "/system/reset", self.reset_callback, QOS_LATEST)
 
         # slam publisher
         self.slam_publisher: Publisher = self.create_publisher(ConeDetectionStamped, "/slam/global_map", 1)

--- a/src/navigation/py_slam/py_slam/node_track_to_csv.py
+++ b/src/navigation/py_slam/py_slam/node_track_to_csv.py
@@ -7,6 +7,8 @@ from rclpy.node import Node
 
 from driverless_msgs.msg import TrackDetectionStamped
 
+from driverless_common.common import QOS_ALL
+
 
 class TrackToCSV(Node):
     csv_folder = Path("./csv_data")
@@ -15,7 +17,7 @@ class TrackToCSV(Node):
         super().__init__("track_to_csv_node")
 
         # subscribe to topic
-        self.subscription = self.create_subscription(TrackDetectionStamped, "/slam/global_map", self.callback, 10)
+        self.subscription = self.create_subscription(TrackDetectionStamped, "/slam/global_map", self.callback, QOS_ALL)
 
         self.get_logger().info("---Track to CSV writer node initalised---")
 

--- a/src/navigation/py_slam/py_slam/node_wss_slam.py
+++ b/src/navigation/py_slam/py_slam/node_wss_slam.py
@@ -1,10 +1,9 @@
-from math import atan2, cos, hypot, pi, sin, sqrt
-import time
+from math import atan2, cos, hypot, pi, sin
 
 import numpy as np
 from sklearn.neighbors import KDTree
 from tf2_ros import TransformBroadcaster
-from transforms3d.euler import euler2quat, quat2euler
+from transforms3d.euler import euler2quat
 
 import message_filters
 import rclpy
@@ -14,7 +13,7 @@ from rclpy.publisher import Publisher
 from driverless_msgs.msg import ConeDetectionStamped, ConeWithCovariance, Reset, TrackDetectionStamped, WSSVelocity
 from geometry_msgs.msg import Point, PoseWithCovarianceStamped, Quaternion, TransformStamped, TwistStamped
 
-from driverless_common.shutdown_node import ShutdownNode
+from driverless_common.common import QOS_ALL, QOS_LATEST
 from py_slam.cone_props import ConeProps
 
 from typing import List, Optional
@@ -55,9 +54,9 @@ class WSSSlam(Node):
         vel_synchronizer = message_filters.ApproximateTimeSynchronizer(fs=[imu_sub, wss_sub], queue_size=10, slop=0.1)
         vel_synchronizer.registerCallback(self.velocity_callback)
 
-        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.vision_callback, 1)
-        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.lidar_callback, 1)
-        self.create_subscription(Reset, "/system/reset", self.reset_callback, 10)
+        self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.vision_callback, QOS_ALL)
+        self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.lidar_callback, QOS_LATEST)
+        self.create_subscription(Reset, "/system/reset", self.reset_callback, QOS_LATEST)
 
         # slam publisher
         self.slam_publisher: Publisher = self.create_publisher(TrackDetectionStamped, "/slam/global_map", 1)

--- a/src/navigation/slam/CMakeLists.txt
+++ b/src/navigation/slam/CMakeLists.txt
@@ -23,7 +23,7 @@ set (SOURCES
 )
 
 add_executable(node_ekf_slam src/ekf_slam/node_ekf_slam.cpp ${SOURCES})
-
+target_include_directories(node_ekf_slam PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
 target_include_directories(node_ekf_slam PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/src/navigation/slam/experiment_runner.py
+++ b/src/navigation/slam/experiment_runner.py
@@ -12,6 +12,7 @@ from rclpy.node import Node
 
 from nav_msgs.msg import Odometry
 
+from driverless_common.common import QOS_ALL
 from experiment_helpers import float_point_one_range, get_run_name, range_slam_testing_lists
 
 
@@ -69,7 +70,7 @@ class DataWatcherNode(Node):
     ):
         super().__init__("data_grabber")
 
-        self.create_subscription(Odometry, "/ground_truth/odom", self.callback, 10)
+        self.create_subscription(Odometry, "/ground_truth/odom", self.callback, QOS_ALL)
 
         self.processes = processes
 

--- a/src/navigation/slam/src/ekf_slam/node_ekf_slam.cpp
+++ b/src/navigation/slam/src/ekf_slam/node_ekf_slam.cpp
@@ -13,6 +13,7 @@
 #include "../markers.h"
 #include "ackermann_msgs/msg/ackermann_drive.hpp"
 #include "builtin_interfaces/msg/time.hpp"
+#include "driverless_common/common.hpp"
 #include "driverless_msgs/msg/cone.hpp"
 #include "driverless_msgs/msg/cone_detection_stamped.hpp"
 #include "driverless_msgs/msg/debug_msg.hpp"
@@ -76,10 +77,10 @@ class EKFSLAMNode : public rclcpp::Node {
    public:
     EKFSLAMNode() : Node("ekf_node") {
         twist_sub = create_subscription<geometry_msgs::msg::TwistStamped>(
-            "velocity", 10, std::bind(&EKFSLAMNode::twist_callback, this, _1));
+            "velocity", QOS_ALL, std::bind(&EKFSLAMNode::twist_callback, this, _1));
 
         detection_sub = create_subscription<driverless_msgs::msg::ConeDetectionStamped>(
-            "cone_detection", 1, std::bind(&EKFSLAMNode::cone_detection_callback, this, _1));
+            "cone_detection", QOS_LATEST, std::bind(&EKFSLAMNode::cone_detection_callback, this, _1));
 
         pose_pub = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("slam/pose", 10);
         track_pub = create_publisher<driverless_msgs::msg::ConeDetectionStamped>("slam/track", 10);

--- a/src/operations/mission_controller/mission_controller/node_inspection_handler.py
+++ b/src/operations/mission_controller/mission_controller/node_inspection_handler.py
@@ -4,6 +4,7 @@ from rclpy.publisher import Publisher
 
 from driverless_msgs.msg import Reset, Shutdown
 
+from driverless_common.common import QOS_LATEST
 from driverless_common.shutdown_node import ShutdownNode
 
 
@@ -13,8 +14,8 @@ class InspectionHandler(ShutdownNode):
     def __init__(self):
         super().__init__("inspection_logic_node")
         self.timer = self.create_timer(30, self.timer_callback)
+        self.reset_sub = self.create_subscription(Reset, "/system/reset", self.reset_callback, QOS_LATEST)
         self.shutdown_pub: Publisher = self.create_publisher(Shutdown, "/system/shutdown", 1)
-        self.reset_sub = self.create_subscription(Reset, "/system/reset", self.reset_callback, 10)
 
         self.get_logger().info("---Inspection handler node initialised---")
 

--- a/src/operations/mission_controller/package.xml
+++ b/src/operations/mission_controller/package.xml
@@ -14,6 +14,7 @@
     <depend>py_slam</depend>
     <depend>vision_pipeline</depend>
     <depend>planners</depend>
+    <depend>driverless_common</depend>
 
     <export>
         <build_type>ament_python</build_type>

--- a/src/operations/terminal_control/package.xml
+++ b/src/operations/terminal_control/package.xml
@@ -10,6 +10,7 @@
     <!-- Messages -->
     <depend>driverless_msgs</depend>
     <depend>ackermann_msgs</depend>
+    <depend>driverless_common</depend>
 
     <export>
         <build_type>ament_python</build_type>

--- a/src/operations/terminal_control/terminal_control/node_controller.py
+++ b/src/operations/terminal_control/terminal_control/node_controller.py
@@ -8,6 +8,7 @@ from ackermann_msgs.msg import AckermannDriveStamped
 from driverless_msgs.msg import Reset, State
 from std_msgs.msg import Bool, UInt8
 
+from driverless_common.common import QOS_LATEST
 from driverless_common.status_constants import INT_MISSION_TYPE, INT_STATE_TYPE
 
 SPEED_MIN = 0.0
@@ -31,7 +32,7 @@ class KeyboardControllerNode(Node):
     def __init__(self):
         super().__init__("terminal_controller_node")
 
-        self.state_sub: Publisher = self.create_subscription(State, "/system/as_status", self.state_callback, 1)
+        self.state_subr = self.create_subscription(State, "/system/as_status", self.state_callback, QOS_LATEST)
 
         self.drive_command_publisher: Publisher = self.create_publisher(
             AckermannDriveStamped, "/control/driving_command", 1

--- a/src/perception/cpp_lidar/CMakeLists.txt
+++ b/src/perception/cpp_lidar/CMakeLists.txt
@@ -21,7 +21,7 @@ set (SOURCES
 )
 
 add_executable(detector src/node_detector.cpp ${SOURCES})
-
+target_include_directories(detector PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
 target_include_directories(detector PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/src/perception/cpp_lidar/src/node_detector.cpp
+++ b/src/perception/cpp_lidar/src/node_detector.cpp
@@ -15,6 +15,7 @@
 #include <rclcpp/time.hpp>
 
 #include "dbscan.h"
+#include "driverless_common/common.hpp"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
@@ -50,7 +51,7 @@ class LiDARProcessor : public rclcpp::Node {
     LiDARProcessor() : Node("lidar_processor") {
         // Create a ROS subscriber for the input point cloud
         cloud_sub = this->create_subscription<sensor_msgs::msg::PointCloud2>(
-            "/velodyne_points", 10, std::bind(&LiDARProcessor::cloud_callback, this, _1));
+            "/velodyne_points", QOS_ALL, std::bind(&LiDARProcessor::cloud_callback, this, _1));
 
         // Create a ROS publisher for the output point cloud
         ground_pub = this->create_publisher<sensor_msgs::msg::PointCloud2>("/velodyne/ground", 1);

--- a/src/perception/hsv_thresholder/hsv_thresholder/node_thresholder.py
+++ b/src/perception/hsv_thresholder/hsv_thresholder/node_thresholder.py
@@ -9,6 +9,8 @@ from rclpy.publisher import Publisher
 from sensor_msgs.msg import Image
 from std_msgs.msg import String
 
+from driverless_common.common import QOS_LATEST
+
 from .threshold import Threshold
 
 cv_bridge = CvBridge()
@@ -17,15 +19,9 @@ cv_bridge = CvBridge()
 class ThresholderNode(Node):
     def __init__(self):
         super().__init__("thresholder")
-        self.create_subscription(String, "hsv_thresholder/threshold", self.threshold_callback, 1)
-        self.create_subscription(
-            Image,
-            "/zed2i/zed_node/rgb/image_rect_color",
-            self.image_callback,
-            1,
-        )
-
-        self.threshold_img_publisher: Publisher = self.create_publisher(Image, "hsv_thresholder/thresholded_img", 1)
+        self.create_subscription(String, "hsv_thresholder/threshold", self.threshold_callback, QOS_LATEST)
+        self.create_subscription(Image, "/zed2i/zed_node/rgb/image_rect_color", self.image_callback, QOS_LATEST)
+        threshold_img_publisher: Publisher = self.create_publisher(Image, "hsv_thresholder/thresholded_img", 1)
 
         self.threshold = Threshold(
             lower=[0, 0, 0],

--- a/src/perception/hsv_thresholder/package.xml
+++ b/src/perception/hsv_thresholder/package.xml
@@ -9,6 +9,7 @@
 
     <depend>std_msgs</depend>
     <depend>sensor_msgs</depend>
+    <depend>driverless_common</depend>
 
     <export>
         <build_type>ament_python</build_type>

--- a/src/perception/lidar_pipeline/lidar_pipeline/node_detector.py
+++ b/src/perception/lidar_pipeline/lidar_pipeline/node_detector.py
@@ -1,7 +1,5 @@
 import time
 
-import numpy as np
-
 import rclpy
 from rclpy.node import Node
 from rclpy.publisher import Publisher
@@ -10,6 +8,8 @@ from rclpy.subscription import Subscription
 from driverless_msgs.msg import Cone, ConeDetectionStamped
 from geometry_msgs.msg import Point
 from sensor_msgs.msg import PointCloud2, PointField
+
+from driverless_common.common import QOS_ALL
 
 from .process import *
 
@@ -97,8 +97,8 @@ class LiDARDetectorNode(Node):
         self.average_runtime: float = 0
 
         # Create subscribers and publishers
-        self.pointcloud_sub: Subscription = self.create_subscription(PointCloud2, "/velodyne_points", self.callback, 1)
-        self.detection_publisher: Publisher = self.create_publisher(ConeDetectionStamped, "/lidar/cone_detection", 1)
+        self.pointcloud_sub = self.create_subscription(PointCloud2, "/velodyne_points", self.callback, QOS_ALL)
+        self.detection_publisher = self.create_publisher(ConeDetectionStamped, "/lidar/cone_detection", 1)
 
         # Log info
         self.get_logger().info("---LiDAR detector node initialised---")

--- a/src/perception/lidar_pipeline/lidar_pipeline/node_lidar_debug.py
+++ b/src/perception/lidar_pipeline/lidar_pipeline/node_lidar_debug.py
@@ -14,6 +14,8 @@ from driverless_msgs.msg import Cone, ConeDetectionStamped
 from geometry_msgs.msg import Point
 from sensor_msgs.msg import PointCloud2, PointField
 
+from driverless_common.common import QOS_ALL
+
 from .library import constants as const
 from .library import lidar_manager, video_stitcher
 from .library.utils import Config  # For typing
@@ -96,7 +98,7 @@ class ConeDetectionNode(Node):
 
         # Create subscribers and publishers
         self.pc_subscription: Subscription = self.create_subscription(
-            PointCloud2, self.config.pc_node, self.pc_callback, 1
+            PointCloud2, self.config.pc_node, self.pc_callback, QOS_ALL
         )
         self.cone_publisher: Publisher = self.create_publisher(ConeDetectionStamped, "/lidar/cone_detection", 1)
 

--- a/src/perception/lidar_pipeline/package.xml
+++ b/src/perception/lidar_pipeline/package.xml
@@ -9,7 +9,7 @@
 
     <depend>rclpy</depend>
     <depend>sensor_msgs</depend>
-	<depend>driverless_msgs</depend>
+    <depend>driverless_msgs</depend>
     <depend>driverless_common</depend>
 
     <export>

--- a/src/perception/lidar_pipeline/package.xml
+++ b/src/perception/lidar_pipeline/package.xml
@@ -10,6 +10,7 @@
     <depend>rclpy</depend>
     <depend>sensor_msgs</depend>
 	<depend>driverless_msgs</depend>
+    <depend>driverless_common</depend>
 
     <export>
         <build_type>ament_python</build_type>

--- a/src/perception/vision_pipeline/package.xml
+++ b/src/perception/vision_pipeline/package.xml
@@ -12,6 +12,7 @@
     <!-- Messages -->
     <depend>geometry_msgs</depend>
     <depend>driverless_msgs</depend>
+    <depend>driverless_common</depend>
     <depend>sensor_msgs</depend>
     <depend>std_msgs</depend>
 

--- a/src/perception/vision_pipeline/vision_pipeline/node_image_saver.py
+++ b/src/perception/vision_pipeline/vision_pipeline/node_image_saver.py
@@ -6,6 +6,8 @@ from rclpy.node import Node
 
 from sensor_msgs.msg import Image
 
+from driverless_common.common import QOS_ALL
+
 
 class BagToImageFile(Node):
     bridge = CvBridge()
@@ -15,7 +17,7 @@ class BagToImageFile(Node):
     def __init__(self):
         super().__init__("bag_to_image_file_node")
         self.subscription = self.create_subscription(
-            Image, "/zed2i/zed_node/rgb/image_rect_color", self.listener_callback, 10
+            Image, "/zed2i/zed_node/rgb/image_rect_color", self.listener_callback, QOS_ALL
         )
 
         # create a folder for the images


### PR DESCRIPTION
## What type of PR is this?
Bug Fix... ish

## Description + Documentation
https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Quality-of-Service-Settings.html
This article explains what QoS (quality of service) is and how to use it properly. Simply put, QoS policies give us control over how publishers and subscribers manage messages up until they are processed. Internally, subscribers store the messages they receive in a queue (the data structure), when the subscriber finishes processing a message, it processes the next message in the queue. As queues are FIFO, the subscriber processes older messages before newer messages, this is not always the behaviour we want. For example, when using the car's pose to calculate the next steering angle, we only ever want to be using the latest pose. The default behaviour of a subscriber is to store the previous 10 messages, in this example, that would mean we calculate the steering angle for where the car was 10 messages ago, and apply it to where the car currently is, leading to the car following a  delayed version of the track.

The `QOS_LATEST` profile will only store one message in its internal queue, meaning it only holds onto the latest message. You should only use this when you only want to process the latest message, and don't care about any messages that you may miss while processing another message. For example, when using car pose to calculate where to steer in order to follow the track, you only want to be using the latest car pose.

The `QOS_ALL` profile will store up to 100 messages in its internal queue. You should use this profile when you need to process all messages sent by the publisher in the order that they are received. For example, /vision/cone_detection subscribers should use this profile as they need to process every message in order to see every cone and build a correct track layout.

### Usability concerns or breaking changes?
As explained in the section above, using QoS profiles incorrectly can lead to hard-to-find bugs, both when used and when not used. This PR touches many subscriptions that I have never used and don't know how to run in order to check that functionality hasn't been changed. Please review subscriptions that you have used before, you don't need to run them, but ensure the surrounding node still works. You should ask, does the subscription's callback change the node's state, and if so is the change idempotent, if so, use `QOS_LATEST` otherwise use `QOS_ALL`.
