### PR TITLE
Build: Export compile commands for us Clion users.

### DIFF
--- a/tools/qutms_cli_tools/qutms_cli_tools/build.py
+++ b/tools/qutms_cli_tools/qutms_cli_tools/build.py
@@ -20,6 +20,8 @@ def main():
     command_prefix = [
         "colcon",
         "build",
+        "--cmake-args",
+        "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
         "--symlink-install",
     ]
 


### PR DESCRIPTION
Clion uses a build file called compile_commands.json for its intellisense, this PR makes the qutms_cli_tools generate that file when building. 

Google Drive docs updated.