### PR TITLE
Inherit particle pursuit

### DIFF
--- a/src/control/path_follower/path_follower/node_particle_pursuit_inherit.py
+++ b/src/control/path_follower/path_follower/node_particle_pursuit_inherit.py
@@ -1,0 +1,159 @@
+from math import atan2, cos, dist, pi, sin, sqrt
+import time
+
+import cv2
+import numpy as np
+import scipy.spatial
+from transforms3d.euler import quat2euler
+
+from cv_bridge import CvBridge
+import rclpy
+
+from ackermann_msgs.msg import AckermannDriveStamped
+from driverless_msgs.msg import Cone, ConeDetectionStamped
+from geometry_msgs.msg import PoseWithCovarianceStamped
+
+from driverless_common.common import angle, fast_dist, wrap_to_pi
+from path_follower.node_pure_pursuit import PurePursuit
+
+from typing import List
+
+# ADD QOS PROFILES
+
+LEFT_CONE_COLOUR = Cone.BLUE
+RIGHT_CONE_COLOUR = Cone.YELLOW
+
+cv_bridge = CvBridge()
+WIDTH = 1000
+HEIGHT = 1000
+
+
+def get_closest_cone(pos_car: List[float], boundaries: np.ndarray) -> float:
+    """
+    Gets the position of the nearest cone to the car.
+    * param pos_car: [x,y] coords of car position
+    * param boundaries: [x,y] coords of all current cones
+    * return: [x,y] of nearest cone to the car
+    """
+
+    # get arrays of only coords for more efficient compute
+    _pos = np.array([[pos_car[0], pos_car[1]]])
+    boundaries_coords = np.array(boundaries[:, :2])
+
+    # find distances of all cones and index of closest cone (improve by finding distances of close cones only?)
+    dists: np.ndarray = scipy.spatial.distance.cdist(
+        boundaries_coords,
+        _pos,
+        "euclidean",
+    )
+    # not certain np.where is returning the index - it should though
+    nearest_cone_index: int = np.where(dists == np.amin(dists))[0][0]
+
+    nearest_cone = boundaries_coords[nearest_cone_index]
+    return nearest_cone
+
+
+class ParticlePursuit(PurePursuit):
+    """
+    This inherits from PurePursuit as the underlying path following algorithm is the same
+
+    Avoidance adapted from: https://link.springer.com/chapter/10.1007/978-3-031-10047-5_5
+    * Treats the vehicle as a charged point particle, interacting \
+    * with two external charged forces (barrier - repulsive, lookahead - attractive).
+    """
+
+    # ------------------------------
+    track = np.array([])
+
+    # attractive force constants:
+    k_attractive: float = 3  # attractive force gain
+
+    # repulsive force constants:
+    d_min: float = 1.3  # min repulsive force distance (max. repulsion at or below)
+    d_max: float = 2.0  # max repulsive force distance (zero repulsion at or above)
+    k_repulsive: float = 0  # repulsive force gain
+
+    # cone_danger - a unitless, *inverse* 'spring constant' of the repulsive force (gamma in documentation)
+    # E.g. cone_danger > 0: corners cut tighter
+    #      cone_danger < 0: corners taken wider
+    #      ** dont set to 1.0 **
+    cone_danger: float = 0.0
+
+    def __init__(self):
+        super().__init__("particle_pursuit")
+
+        # sub to track for all cone locations relative to car start point, used for boundary danger calculations
+        self.create_subscription(ConeDetectionStamped, "/planner/interpolated_map", self.interp_track_callback, 10)
+
+        self.get_logger().info("---Particle pursuit follower initalised---")
+
+    # recieve the cone locations
+    def interp_track_callback(self, cone_pos_msg: ConeDetectionStamped):
+        self.get_logger().debug("Map received")
+
+        ## MOVED FROM CALLBACK AS THIS ONLY HAS TO HAPPEN ONCE
+        # get left and right cones
+        left_cones = [c for c in cone_pos_msg.cones if c.color == LEFT_CONE_COLOUR]
+        right_cones = [c for c in cone_pos_msg.cones if c.color == RIGHT_CONE_COLOUR]
+
+        if len(left_cones) == 0 or len(right_cones) == 0:  # no cones
+            return
+
+        # order cones by distance from car
+        left_cones.sort(key=lambda c: c.location.x)
+        right_cones.sort(key=lambda c: c.location.x)
+
+        # make one array with alternating left and right cones
+        cones = left_cones + right_cones
+        self.track = np.array([[c.location.x, c.location.y] for c in cones])
+
+    def callback(self, msg: PoseWithCovarianceStamped):
+        # Only start once the path and map has been recieved,
+        # it's a following lap, and we are ready to drive
+        if not self.following or not self.r2d or self.path.size == 0:  # or self.track.size == 0:
+            return
+
+        start_time = time.time()
+
+        # i, j, k angles in rad
+        theta = quat2euler(
+            [
+                msg.pose.pose.orientation.w,
+                msg.pose.pose.orientation.x,
+                msg.pose.pose.orientation.y,
+                msg.pose.pose.orientation.z,
+            ]
+        )[2]
+        # get the position of the center of gravity
+        position_cog: List[float] = [msg.pose.pose.position.x, msg.pose.pose.position.y]
+        position: List[float] = self.get_wheel_position(position_cog, theta)
+
+        # rvwp control
+        rvwp: List[float] = self.get_rvwp(position)
+
+        des_heading_ang = angle(position, [rvwp[0], rvwp[1]])
+        error = wrap_to_pi(theta - des_heading_ang)
+        steering_angle = np.rad2deg(error) * self.Kp_ang
+
+        if self.DEBUG_IMG:
+            debug_img = self.draw_rvwp(self.path, rvwp, position, steering_angle, self.vel_max)
+            self.debug_publisher.publish(cv_bridge.cv2_to_imgmsg(debug_img, encoding="bgr8"))
+
+        # publish message
+        control_msg = AckermannDriveStamped()
+        control_msg.drive.steering_angle = steering_angle
+        control_msg.drive.speed = self.vel_max
+        self.control_publisher.publish(control_msg)
+
+        self.count += 1
+        if self.count == 50:
+            self.count = 0
+            self.get_logger().info(f"{(time.time() - start_time) * 1000}")
+
+
+def main(args=None):  # begin ros node
+    rclpy.init(args=args)
+    node = ParticlePursuit()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()

--- a/src/control/path_follower/path_follower/node_pure_pursuit.py
+++ b/src/control/path_follower/path_follower/node_pure_pursuit.py
@@ -173,7 +173,7 @@ class PurePursuit(Node):
         target_vel = self.vel_max
 
         if self.DEBUG_IMG:
-            debug_img = self.draw_rvwp(rvwp, pose[:2], steering_angle, target_vel)
+            debug_img = self.draw_rvwp(rvwp, pose[:2], steering_angle, target_vel)[0]
             self.debug_publisher.publish(cv_bridge.cv2_to_imgmsg(debug_img, encoding="bgr8"))
 
         # publish message
@@ -246,7 +246,7 @@ class PurePursuit(Node):
         text_vel = "Velocity: " + str(round(velocity, 2))
         cv2.putText(debug_img, text_vel, (10, HEIGHT - 25), cv2.FONT_HERSHEY_SIMPLEX, 1.5, (255, 255, 255), 4)
 
-        return debug_img
+        return debug_img, scale, x_offset, y_offset
 
 
 def main(args=None):  # begin ros node

--- a/src/control/path_follower/path_follower/node_pure_pursuit.py
+++ b/src/control/path_follower/path_follower/node_pure_pursuit.py
@@ -27,33 +27,15 @@ WIDTH = 1000
 HEIGHT = 1000
 
 
-def get_wheel_position(pos_cog: List[float], heading: float) -> List[float]:
-    """
-    Gets the position of the steering axle from the car's center of gravity and heading
-    * param pos_cog: [x,y] coords of the car's center of gravity
-    * param heading: car's heading in rads
-    * return: [x,y] position of steering axle
-    """
-    cog2axle = 0.5  # m
-    x_axle = pos_cog[0] + cos(heading) * cog2axle
-    y_axle = pos_cog[1] + sin(heading) * cog2axle
-
-    return [x_axle, y_axle, heading]
-
-
 class PurePursuit(Node):
     path = np.array([])
     count = 0
-    img_initialised = False
-    scale = 1
-    x_offset = 0
-    y_offset = 0
     following = False
     r2d = False
     fallback_path_points_offset = 0
 
-    def __init__(self):
-        super().__init__("pure_pursuit_node")
+    def __init__(self, node_name: str = "pure_pursuit_node"):
+        super().__init__(node_name)
 
         # subscribers
         self.create_subscription(Bool, "/system/r2d", self.r2d_callback, 10)
@@ -72,7 +54,8 @@ class PurePursuit(Node):
         self.vel_max = self.declare_parameter("vel_max", 5.0).value
         self.DEBUG_IMG = self.declare_parameter("debug_img", True).value
 
-        self.get_logger().info("---Pure pursuit follower initalised---")
+        if node_name == "pure_pursuit_node":
+            self.get_logger().info("---Pure pursuit follower initalised---")
 
     def r2d_callback(self, msg: Bool):
         if msg.data:
@@ -88,6 +71,19 @@ class PurePursuit(Node):
             self.get_logger().info("Lap completed, following commencing")
         else:
             self.following = False
+
+    def get_wheel_position(self, pos_cog: List[float], heading: float) -> List[float]:
+        """
+        Gets the position of the steering axle from the car's center of gravity and heading
+        * param pos_cog: [x,y] coords of the car's center of gravity
+        * param heading: car's heading in rads
+        * return: [x,y] position of steering axle
+        """
+        cog2axle = 0.5  # m
+        x_axle = pos_cog[0] + cos(heading) * cog2axle
+        y_axle = pos_cog[1] + sin(heading) * cog2axle
+
+        return [x_axle, y_axle, heading]
 
     def get_rvwp(self, car_pos: List[float]):
         """
@@ -150,27 +146,6 @@ class PurePursuit(Node):
         # path points that should be skipped.
         self.fallback_path_points_offset = int(round(len(self.path) / distance * self.lookahead))
 
-        if not self.img_initialised:
-            # get dimensions of the path
-            path_x_min = np.min(self.path[:, 0])
-            path_x_max = np.max(self.path[:, 0])
-            path_y_min = np.min(self.path[:, 1])
-            path_y_max = np.max(self.path[:, 1])
-
-            # scale the path to fit in a 1000x1000 image, pixels per meter
-            self.scale = WIDTH / max(path_x_max - path_x_min, path_y_max - path_y_min)
-
-            # add a border around the path for all elements
-            self.scale *= 0.90
-
-            # set offsets to the corner of the image
-            self.x_offset = -path_x_min * self.scale
-            self.x_offset += (WIDTH - (path_x_max - path_x_min) * self.scale) / 2
-            self.y_offset = -path_y_min * self.scale
-            self.y_offset += (HEIGHT - (path_y_max - path_y_min) * self.scale) / 2
-
-            self.img_initialised = True
-
     def callback(self, msg: PoseWithCovarianceStamped):
         # Only start once the path has been recieved, it's a following lap, and we are ready to drive
         if not self.following or not self.r2d or self.path.size == 0:
@@ -189,7 +164,7 @@ class PurePursuit(Node):
         )[2]
         # get the position of the center of gravity
         position_cog: List[float] = [msg.pose.pose.position.x, msg.pose.pose.position.y]
-        position: List[float] = get_wheel_position(position_cog, theta)
+        position: List[float] = self.get_wheel_position(position_cog, theta)
 
         # rvwp control
         rvwp: List[float] = self.get_rvwp(position)
@@ -199,45 +174,7 @@ class PurePursuit(Node):
         steering_angle = np.rad2deg(error) * self.Kp_ang
 
         if self.DEBUG_IMG:
-            debug_img = np.zeros((HEIGHT, WIDTH, 3), np.uint8)
-            for i in range(0, len(self.path) - 1):
-                cv2.line(
-                    debug_img,
-                    (
-                        int(self.path[i, 0] * self.scale + self.x_offset),
-                        int(self.path[i, 1] * self.scale + self.y_offset),
-                    ),
-                    (
-                        int(self.path[i + 1, 0] * self.scale + self.x_offset),
-                        int(self.path[i + 1, 1] * self.scale + self.y_offset),
-                    ),
-                    (255, 0, 0),
-                    thickness=5,
-                )
-
-            cv2.drawMarker(
-                debug_img,
-                (int(rvwp[0] * self.scale + self.x_offset), int(rvwp[1] * self.scale + self.y_offset)),
-                (0, 255, 0),
-                markerType=cv2.MARKER_TRIANGLE_UP,
-                markerSize=10,
-                thickness=4,
-            )
-
-            cv2.drawMarker(
-                debug_img,
-                (int(position[0] * self.scale + self.x_offset), int(position[1] * self.scale + self.y_offset)),
-                (0, 0, 255),
-                markerType=cv2.MARKER_TRIANGLE_UP,
-                markerSize=10,
-                thickness=4,
-            )
-            cv2.flip(debug_img, 1, debug_img)
-
-            text_angle = "Steering: " + str(round(steering_angle, 2))
-            cv2.putText(debug_img, text_angle, (10, HEIGHT - 75), cv2.FONT_HERSHEY_SIMPLEX, 1.5, (255, 255, 255), 4)
-            text_vel = "Velocity: " + str(round(self.vel_max, 2))
-            cv2.putText(debug_img, text_vel, (10, HEIGHT - 25), cv2.FONT_HERSHEY_SIMPLEX, 1.5, (255, 255, 255), 4)
+            debug_img = self.draw_rvwp(self.path, rvwp, position, steering_angle, self.vel_max)
             self.debug_publisher.publish(cv_bridge.cv2_to_imgmsg(debug_img, encoding="bgr8"))
 
         # publish message
@@ -250,6 +187,67 @@ class PurePursuit(Node):
         if self.count == 50:
             self.count = 0
             self.get_logger().info(f"{(time.time() - start_time) * 1000}")
+
+    def draw_rvwp(self, rvwp: List[float], position: List[float], steering_angle: float, velocity: float):
+        # get dimensions of the path
+        path_x_min = np.min(self.path[:, 0])
+        path_x_max = np.max(self.path[:, 0])
+        path_y_min = np.min(self.path[:, 1])
+        path_y_max = np.max(self.path[:, 1])
+
+        # scale the path to fit in a 1000x1000 image, pixels per meter
+        scale = WIDTH / max(path_x_max - path_x_min, path_y_max - path_y_min)
+
+        # add a border around the path for all elements
+        scale *= 0.90
+
+        # set offsets to the corner of the image
+        x_offset = -path_x_min * scale
+        x_offset += (WIDTH - (path_x_max - path_x_min) * scale) / 2
+        y_offset = -path_y_min * scale
+        y_offset += (HEIGHT - (path_y_max - path_y_min) * scale) / 2
+
+        debug_img = np.zeros((HEIGHT, WIDTH, 3), np.uint8)
+        for i in range(0, len(self.path) - 1):
+            cv2.line(
+                debug_img,
+                (
+                    int(self.path[i, 0] * scale + x_offset),
+                    int(self.path[i, 1] * scale + y_offset),
+                ),
+                (
+                    int(self.path[i + 1, 0] * scale + x_offset),
+                    int(self.path[i + 1, 1] * scale + y_offset),
+                ),
+                (255, 0, 0),
+                thickness=5,
+            )
+
+        cv2.drawMarker(
+            debug_img,
+            (int(rvwp[0] * scale + x_offset), int(rvwp[1] * scale + y_offset)),
+            (0, 255, 0),
+            markerType=cv2.MARKER_TRIANGLE_UP,
+            markerSize=10,
+            thickness=4,
+        )
+
+        cv2.drawMarker(
+            debug_img,
+            (int(position[0] * scale + x_offset), int(position[1] * scale + y_offset)),
+            (0, 0, 255),
+            markerType=cv2.MARKER_TRIANGLE_UP,
+            markerSize=10,
+            thickness=4,
+        )
+        cv2.flip(debug_img, 1, debug_img)
+
+        text_angle = "Steering: " + str(round(steering_angle, 2))
+        cv2.putText(debug_img, text_angle, (10, HEIGHT - 75), cv2.FONT_HERSHEY_SIMPLEX, 1.5, (255, 255, 255), 4)
+        text_vel = "Velocity: " + str(round(velocity, 2))
+        cv2.putText(debug_img, text_vel, (10, HEIGHT - 25), cv2.FONT_HERSHEY_SIMPLEX, 1.5, (255, 255, 255), 4)
+
+        return debug_img
 
 
 def main(args=None):  # begin ros node

--- a/src/control/path_follower/setup.py
+++ b/src/control/path_follower/setup.py
@@ -20,8 +20,9 @@ setup(
     entry_points={
         "console_scripts": [
             "pure_pursuit = path_follower.node_pure_pursuit:main",
-            "particle_pursuit = path_follower.node_particle_pursuit:main",
             "pure_pursuit_kdtree = path_follower.node_pure_pursuit_kdtree:main",
+            "particle_pursuit = path_follower.node_particle_pursuit:main",
+            "particle_pursuit_inherit = path_follower.node_particle_pursuit_inherit:main",
         ],
     },
 )

--- a/src/operations/mission_controller/launch/trackdrive.launch.py
+++ b/src/operations/mission_controller/launch/trackdrive.launch.py
@@ -21,7 +21,7 @@ def generate_launch_description():
             ),
             Node(
                 package="path_follower",
-                executable="pure_pursuit",
+                executable="particle_pursuit_inherit",
             ),
             Node(
                 package="planners",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide evidence of tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimisation

## [required] Description

Work on an inherited particle pursuit node which has the base methods within pure pursuite (rvwp, storing path, debug drawing etc).
Also integrated the boundary interpolation into the current spline planner as it uses the ordered cones.

### [optional] Usability concerns or breaking changes?

Pure pursuit was made slightly more object oriented to suit the inheritance. No breaking issues, but code will be in difference places (class methods now).

