### PR TITLE
Missions use states

### DIFF
--- a/src/common/driverless_msgs/msg/State.msg
+++ b/src/common/driverless_msgs/msg/State.msg
@@ -20,3 +20,5 @@ uint8 MANUAL_DRIVING=1
 uint8 INSPECTION=2
 uint8 EBS_TEST=3
 uint8 TRACKDRIVE=4
+
+uint8 lap_count

--- a/src/control/controllers/controllers/node_reactive_control.py
+++ b/src/control/controllers/controllers/node_reactive_control.py
@@ -1,5 +1,6 @@
-import numpy as np
 import time
+
+import numpy as np
 
 import rclpy
 from rclpy.node import Node

--- a/src/control/controllers/controllers/node_reactive_control.py
+++ b/src/control/controllers/controllers/node_reactive_control.py
@@ -69,7 +69,7 @@ class ReactiveController(Node):
             self.driving = True
             self.get_logger().info("Ready to drive, discovery started")
         # lap has been completed, stop this controller
-        if msg.lap_count > 0 and not self.discovering:
+        if msg.lap_count > 0 and self.discovering:
             self.discovering = False
             self.get_logger().debug("Lap completed, discovery stopped")
 

--- a/src/control/controllers/controllers/node_reactive_control.py
+++ b/src/control/controllers/controllers/node_reactive_control.py
@@ -51,7 +51,7 @@ class ReactiveController(Node):
             # self.create_subscription(ConeDetectionStamped, "/vision/cone_detection", self.callback, 1)
             self.create_subscription(ConeDetectionStamped, "/lidar/cone_detection", self.callback, QOS_ALL)
         else:
-            self.Kp_ang = 2.0
+            self.Kp_ang = 2.5
             self.target_vel = 1.5  # m/s
             self.target_accel = 0.0
             self.target_cone_count = 2

--- a/src/control/controllers/controllers/node_reactive_control.py
+++ b/src/control/controllers/controllers/node_reactive_control.py
@@ -1,12 +1,12 @@
 import numpy as np
+import time
 
 import rclpy
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 
 from ackermann_msgs.msg import AckermannDriveStamped
-from driverless_msgs.msg import Cone, ConeDetectionStamped
-from std_msgs.msg import Bool, UInt8
+from driverless_msgs.msg import Cone, ConeDetectionStamped, State
 
 from driverless_common.common import QOS_ALL, QOS_LATEST
 from driverless_common.point import Point, cone_to_point, dist
@@ -31,7 +31,7 @@ class ReactiveController(Node):
     pub_accel: bool
     ebs_test: bool
     discovering: bool = True
-    r2d: bool = False
+    driving: bool = False
 
     def __init__(self):
         super().__init__("reactive_controller_node")
@@ -39,8 +39,8 @@ class ReactiveController(Node):
         self.ebs_test = self.declare_parameter("ebs_control", False).get_parameter_value().bool_value
         self.get_logger().info("EBS Control: " + str(self.ebs_test))
 
-        self.create_subscription(Bool, "/system/r2d", self.r2d_callback, 10)
-        self.create_subscription(UInt8, "/system/laps_completed", self.lap_callback, 10)
+        # sub to state broadcast to determine what this controller should be doing
+        self.create_subscription(State, "/system/as_status", self.state_callback, QOS_LATEST)
 
         if self.ebs_test:
             self.Kp_ang = 2.0
@@ -61,31 +61,26 @@ class ReactiveController(Node):
 
         self.get_logger().info("---Reactive controller node initalised---")
 
-    def r2d_callback(self, msg: Bool):
-        if msg.data:
-            self.r2d = True
+    def state_callback(self, msg: State):
+        if msg.state == State.DRIVING and not self.driving:
+            # delay starting driving for 2 seconds to allow for mapping to start
+            time.sleep(2)
+            self.driving = True
             self.get_logger().info("Ready to drive, discovery started")
-        else:
-            self.r2d = False
-            self.get_logger().info("Driving disabled")
-
-    def lap_callback(self, msg: UInt8):
         # lap has been completed, stop this controller
-        if msg.data > 0:
+        if msg.lap_count > 0 and not self.discovering:
             self.discovering = False
-            self.get_logger().info("Lap completed, discovery stopped")
-        else:
-            self.discovering = True
+            self.get_logger().debug("Lap completed, discovery stopped")
 
     def callback(self, msg: ConeDetectionStamped):
         self.get_logger().debug("Received detection")
 
+        if not self.discovering or not self.driving:
+            return
+
         # safety critical, set to 0 if not good detection
         speed = 0.0
         steering_angle = 0.0
-
-        if not self.discovering or not self.r2d:
-            return
 
         cones: List[Cone] = msg.cones
 

--- a/src/hardware/vehicle_supervisor/src/node_supervisor_slim.cpp
+++ b/src/hardware/vehicle_supervisor/src/node_supervisor_slim.cpp
@@ -52,6 +52,7 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
     rclcpp::Subscription<driverless_msgs::msg::Shutdown>::SharedPtr shutdown_sub_;
     rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr steering_angle_sub_;
     rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr velocity_sub_;
+    rclcpp::Subscription<std_msgs::msg::UInt8>::SharedPtr lap_sub_;
 
     // publishers
     rclcpp::Publisher<driverless_msgs::msg::Can>::SharedPtr can_pub_;
@@ -66,25 +67,7 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
     float last_steering_angle = 0;
     float last_velocity = 0;
 
-    void velocity_callback(const std_msgs::msg::Float32 msg) {
-        this->last_velocity = msg.data;
-        this->DVL_drivingDynamics1._fields.speed_actual = (int8_t)msg.data;
-        this->run_fsm();
-    }
-
-    void steering_angle_callback(const std_msgs::msg::Float32 msg) {
-        if (msg.data > 1000) {
-            // error in redundant steering angle
-            // go to emergency
-            this->DVL_heartbeat.stateID = DVL_STATES::DVL_STATE_EMERGENCY;
-        } else {
-            this->last_steering_angle = msg.data;
-            this->DVL_drivingDynamics1._fields.steering_angle_actual = (int8_t)msg.data;
-        }
-        this->run_fsm();
-    }
-
-    void can_heartbeat_callback(const driverless_msgs::msg::Can msg) {
+    void can_callback(const driverless_msgs::msg::Can msg) {
         uint32_t qutms_masked_id = msg.id & ~0xF;
 
         // RES boot up
@@ -102,7 +85,6 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
             uint8_t p[8] = {0x01, RES_NODE_ID, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
             this->can_pub_->publish(this->_d_2_f(0x00, false, p, sizeof(p)));
             this->res_alive = 1;
-            this->run_fsm();
         }
         // RES heartbeat
         else if (msg.id == (0x180 + RES_NODE_ID)) {
@@ -121,7 +103,6 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
             res_msg.loss_of_signal_shutdown_notice = this->RES_status.loss_of_signal_shutdown_notice;
             this->res_status_pub_->publish(res_msg);
             this->res_alive = 1;
-            this->run_fsm();
         }
         // VCU hearbeat
         else if (qutms_masked_id == VCU_Heartbeat_ID) {
@@ -144,8 +125,6 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
                 } else {
                     this->DVL_systemStatus._fields.EBS_state = DVL_EBS_STATE_ACTIVATED;
                 }
-
-                this->run_fsm();
             }
         }
         // Steering wheel heartbeat
@@ -157,8 +136,26 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
             Parse_SW_Heartbeat(data, &this->SW_heartbeat);
             RCLCPP_DEBUG(this->get_logger(), "SW State: %02x Mission Id: %d", this->SW_heartbeat.stateID,
                          this->SW_heartbeat.missionID);
-            this->run_fsm();
         }
+        // update state machine following any changes
+        this->run_fsm();
+    }
+
+    void velocity_callback(const std_msgs::msg::Float32 msg) {
+        this->last_velocity = msg.data;
+        this->DVL_drivingDynamics1._fields.speed_actual = (int8_t)msg.data;
+    }
+
+    void steering_angle_callback(const std_msgs::msg::Float32 msg) {
+        if (msg.data > 1000) {
+            // error in redundant steering angle
+            // go to emergency
+            this->DVL_heartbeat.stateID = DVL_STATES::DVL_STATE_EMERGENCY;
+        } else {
+            this->last_steering_angle = msg.data;
+            this->DVL_drivingDynamics1._fields.steering_angle_actual = (int8_t)msg.data;
+        }
+        this->run_fsm();
     }
 
     void control_callback(const ackermann_msgs::msg::AckermannDriveStamped msg) {
@@ -180,11 +177,14 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
         this->DVL_drivingDynamics1._fields.speed_target = (int8_t)msg.drive.speed;
         this->DVL_drivingDynamics1._fields.motor_moment_target = (int8_t)torqueValue;
         this->DVL_drivingDynamics1._fields.motor_moment_actual = (int8_t)torqueValue;
-
-        this->run_fsm();
     }
 
-    void heartbeat_callback() {
+    void lap_counter_callback(const std_msgs::msg::UInt8 msg) {
+        this->ros_state.lap_count = msg.data;
+        this->DVL_systemStatus._fields.lap_counter = msg.data;
+    }
+
+    void dvl_heartbeat_callback() {
         // CAN publisher
         auto heartbeat = Compose_DVL_Heartbeat(&this->DVL_heartbeat);
         this->can_pub_->publish(this->_d_2_f(heartbeat.id, true, heartbeat.data, sizeof(heartbeat.data)));
@@ -270,7 +270,7 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
             this->DVL_systemStatus._fields.AS_state = DVL_AS_State::DVL_AS_STATE_OFF;
 
             // reset mission selections
-            this->ros_state.mission = driverless_msgs::msg::State::MISSION_NONE;
+            this->ros_state.mission = DVL_MISSION::DVL_MISSION_NONE;
             this->DVL_heartbeat.missionID = DVL_MISSION::DVL_MISSION_NONE;
 
             // transition to select mission when res switch is backwards
@@ -294,29 +294,29 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
                 this->ros_state.mission = this->SW_heartbeat.missionID;
             }
 
-            if (this->ros_state.mission != driverless_msgs::msg::State::MISSION_NONE) {
+            if (this->ros_state.mission != DVL_MISSION::DVL_MISSION_NONE) {
+                std::string mission_string;
                 // set mission for logging
-                switch (this->ros_state.mission) {
-                    case DRIVERLESS_MISSIONS::MISSION_INSPECTION:
-                        this->DVL_systemStatus._fields.AMI_state = DVL_AMI_State::DVL_AMI_STATE_INSPECTION;
-                        break;
-                    case DRIVERLESS_MISSIONS::MISSION_EBS:
-                        this->DVL_systemStatus._fields.AMI_state = DVL_AMI_State::DVL_AMI_STATE_BRAKETEST;
-                        break;
-                    case DRIVERLESS_MISSIONS::MISSION_TRACK:
-                        this->DVL_systemStatus._fields.AMI_state = DVL_AMI_State::DVL_AMI_STATE_TRACKDRIVE;
-                        break;
-                    default:
-                        this->DVL_systemStatus._fields.AMI_state = 0;
-                        break;
+                if (this->ros_state.mission == DRIVERLESS_MISSIONS::MISSION_INSPECTION) {
+                    this->DVL_systemStatus._fields.AMI_state = DVL_AMI_State::DVL_AMI_STATE_INSPECTION;
+                    mission_string = "inspection";
+                } else if (this->ros_state.mission == DRIVERLESS_MISSIONS::MISSION_EBS) {
+                    this->DVL_systemStatus._fields.AMI_state = DVL_AMI_State::DVL_AMI_STATE_BRAKETEST;
+                    mission_string = "ebs_test";
+                } else if (this->ros_state.mission == DRIVERLESS_MISSIONS::MISSION_TRACK) {
+                    this->DVL_systemStatus._fields.AMI_state = DVL_AMI_State::DVL_AMI_STATE_TRACKDRIVE;
+                    mission_string = "trackdrive";
+                } else {
+                    this->DVL_systemStatus._fields.AMI_state = 0;
                 }
 
                 // transition to Check EBS state when mission is selected
                 this->DVL_heartbeat.stateID = DVL_STATES::DVL_STATE_CHECK_EBS;
 
                 // set the DVL mission IDs according to selection
-                if (this->ros_state.mission == driverless_msgs::msg::State::MANUAL_DRIVING) {
+                if (this->ros_state.mission == DVL_MISSION::DVL_MISSION_MANUAL) {
                     this->DVL_heartbeat.missionID = DVL_MISSION::DVL_MISSION_MANUAL;
+                    mission_string = "manual_driving";
                 } else {
                     this->DVL_heartbeat.missionID = DVL_MISSION::DVL_MISSION_SELECTED;
                 }
@@ -450,7 +450,9 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
    public:
     ASSupervisor() : Node("vehicle_supervisor_node") {
         // Setup inital states
-        this->ros_state.state = driverless_msgs::msg::State::START;
+        this->ros_state.state = DVL_STATES::DVL_STATE_START;
+        this->ros_state.mission = DVL_MISSION::DVL_MISSION_NONE;
+        this->ros_state.lap_count = 0;
         this->DVL_heartbeat.stateID = DVL_STATES::DVL_STATE_START;
 
         this->reset_dataLogger();
@@ -458,7 +460,7 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
         // CAN
         this->can_pub_ = this->create_publisher<driverless_msgs::msg::Can>("/can/canbus_carbound", 10);
         this->can_sub_ = this->create_subscription<driverless_msgs::msg::Can>(
-            "/can/canbus_rosbound", QOS_ALL, std::bind(&ASSupervisor::can_heartbeat_callback, this, _1));
+            "/can/canbus_rosbound", QOS_ALL, std::bind(&ASSupervisor::can_callback, this, _1));
 
         // State pub
         this->state_pub_ = this->create_publisher<driverless_msgs::msg::State>("/system/as_status", 10);
@@ -481,9 +483,13 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
         this->control_sub_ = this->create_subscription<ackermann_msgs::msg::AckermannDriveStamped>(
             "/control/accel_command", QOS_LATEST, std::bind(&ASSupervisor::control_callback, this, _1));
 
+        // Lap counter sub
+        this->lap_sub_ = this->create_subscription<std_msgs::msg::UInt8>(
+            "/system/laps_completed", QOS_LATEST, std::bind(&ASSupervisor::lap_counter_callback, this, _1));
+
         // AS Heartbeat
         this->heartbeat_timer_ =
-            this->create_wall_timer(std::chrono::milliseconds(20), std::bind(&ASSupervisor::heartbeat_callback, this));
+            this->create_wall_timer(std::chrono::milliseconds(20), std::bind(&ASSupervisor::dvl_heartbeat_callback, this));
 
         // RES Alive
         this->res_alive_timer_ = this->create_wall_timer(std::chrono::milliseconds(1000),

--- a/src/hardware/vehicle_supervisor/src/node_supervisor_slim.cpp
+++ b/src/hardware/vehicle_supervisor/src/node_supervisor_slim.cpp
@@ -488,8 +488,8 @@ class ASSupervisor : public rclcpp::Node, public CanInterface {
             "/system/laps_completed", QOS_LATEST, std::bind(&ASSupervisor::lap_counter_callback, this, _1));
 
         // AS Heartbeat
-        this->heartbeat_timer_ =
-            this->create_wall_timer(std::chrono::milliseconds(20), std::bind(&ASSupervisor::dvl_heartbeat_callback, this));
+        this->heartbeat_timer_ = this->create_wall_timer(std::chrono::milliseconds(20),
+                                                         std::bind(&ASSupervisor::dvl_heartbeat_callback, this));
 
         // RES Alive
         this->res_alive_timer_ = this->create_wall_timer(std::chrono::milliseconds(1000),

--- a/src/navigation/planners/planners/node_ordered_mid_spline.py
+++ b/src/navigation/planners/planners/node_ordered_mid_spline.py
@@ -8,8 +8,9 @@ import rclpy
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 
-from driverless_msgs.msg import Cone, ConeDetectionStamped, PathPoint, State
+from driverless_msgs.msg import Cone, ConeDetectionStamped, PathPoint
 from driverless_msgs.msg import PathStamped as QUTMSPathStamped
+from driverless_msgs.msg import State
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Path
 

--- a/src/navigation/planners/planners/node_ordered_mid_spline.py
+++ b/src/navigation/planners/planners/node_ordered_mid_spline.py
@@ -8,11 +8,10 @@ import rclpy
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 
-from driverless_msgs.msg import Cone, ConeDetectionStamped, PathPoint
+from driverless_msgs.msg import Cone, ConeDetectionStamped, PathPoint, State
 from driverless_msgs.msg import PathStamped as QUTMSPathStamped
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Path
-from std_msgs.msg import UInt8
 
 from driverless_common.common import QOS_LATEST, angle, midpoint
 
@@ -129,7 +128,7 @@ class OrderedMapSpline(Node):
 
         # sub to track for all cone locations relative to car start point
         self.create_subscription(ConeDetectionStamped, "/slam/global_map", self.map_callback, QOS_LATEST)
-        self.create_subscription(UInt8, "/system/laps_completed", self.lap_callback, QOS_LATEST)
+        self.create_subscription(State, "/system/as_status", self.state_callback, QOS_LATEST)
         self.create_timer(0.1, self.planning_callback)
 
         # publishers
@@ -138,8 +137,8 @@ class OrderedMapSpline(Node):
 
         self.get_logger().info("---Ordered path planner node initalised---")
 
-    def lap_callback(self, msg: UInt8):
-        if msg.data > 0:
+    def state_callback(self, msg: State):
+        if msg.state == State.DRIVING and msg.lap_count > 0 and not self.planning:
             self.planning = True
             self.get_logger().info("Lap completed, planning commencing")
 

--- a/src/navigation/planners/planners/node_ordered_mid_spline.py
+++ b/src/navigation/planners/planners/node_ordered_mid_spline.py
@@ -1,6 +1,6 @@
 from math import atan2, pi, sqrt
-from colour import Color
 
+from colour import Color
 import numpy as np
 import scipy.interpolate as scipy_interpolate
 from transforms3d.euler import euler2quat
@@ -14,8 +14,8 @@ from driverless_msgs.msg import PathStamped as QUTMSPathStamped
 from driverless_msgs.msg import State
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Path
-from visualization_msgs.msg import MarkerArray, Marker
 from std_msgs.msg import ColorRGBA
+from visualization_msgs.msg import Marker, MarkerArray
 
 from driverless_common.common import QOS_LATEST, angle, midpoint
 
@@ -142,7 +142,7 @@ def parse_orange_cones(node_logger, orange_cones: List[List[float]]) -> List[Lis
     return [blue_cones[0], blue_cones[1], yellow_cones[0], yellow_cones[1]]
 
 
-def create_marker_array(ordered_cones: List[List[float]], marker_array: MarkerArray, init: int=0) -> MarkerArray:
+def create_marker_array(ordered_cones: List[List[float]], marker_array: MarkerArray, init: int = 0) -> MarkerArray:
     red = Color("red")
     blue = Color("blue")
     col_range = list(blue.range_to(red, len(ordered_cones)))
@@ -150,7 +150,7 @@ def create_marker_array(ordered_cones: List[List[float]], marker_array: MarkerAr
     for i, cone in enumerate(ordered_cones):
         marker = Marker()
         marker.header.frame_id = "track"
-        marker.id = i+init
+        marker.id = i + init
         marker.type = Marker.CYLINDER
         marker.action = Marker.ADD
         marker.pose.position.x = cone[0]
@@ -163,6 +163,7 @@ def create_marker_array(ordered_cones: List[List[float]], marker_array: MarkerAr
         marker_array.markers.append(marker)
 
     return marker_array
+
 
 class OrderedMapSpline(Node):
     spline_const = 10  # number of points per cone
@@ -310,6 +311,7 @@ class OrderedMapSpline(Node):
         qutms_path_msg = QUTMSPathStamped(path=qutms_path)
         qutms_path_msg.header.frame_id = "track"
         self.qutms_path_pub.publish(qutms_path_msg)
+
 
 def main(args=None):
     # begin ros node

--- a/src/navigation/planners/planners/node_ordered_mid_spline.py
+++ b/src/navigation/planners/planners/node_ordered_mid_spline.py
@@ -1,4 +1,5 @@
 from math import atan2, pi, sqrt
+from colour import Color
 
 import numpy as np
 import scipy.interpolate as scipy_interpolate
@@ -13,6 +14,8 @@ from driverless_msgs.msg import PathStamped as QUTMSPathStamped
 from driverless_msgs.msg import State
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Path
+from visualization_msgs.msg import MarkerArray, Marker
+from std_msgs.msg import ColorRGBA
 
 from driverless_common.common import QOS_LATEST, angle, midpoint
 
@@ -118,6 +121,49 @@ def sort_cones(cones, start_index=None, end_index=None):
     return [cones[order[i]] for i in range(len(order))]
 
 
+def parse_orange_cones(node_logger, orange_cones: List[List[float]]) -> List[List[float]]:
+    """
+    Breaks the big orange starting cones into their position relative to the other blue/yellow cones.
+    Returns format close_blue, far_blue, close_yellow, far_yellow.
+    """
+    if len(orange_cones) < 4:
+        node_logger.fatal("parse_orange_cones called with less than 4 visible cones. Requires 4 cones.")
+        return []
+
+    blue_cones = [cone for cone in orange_cones if cone[1] > 0]
+    yellow_cones = [cone for cone in orange_cones if cone[1] < 0]
+
+    if blue_cones[0][0] > blue_cones[1][0]:
+        blue_cones[0], blue_cones[1] = blue_cones[1], blue_cones[0]
+
+    if yellow_cones[0][0] > yellow_cones[1][0]:
+        yellow_cones[0], yellow_cones[1] = yellow_cones[1], yellow_cones[0]
+
+    return [blue_cones[0], blue_cones[1], yellow_cones[0], yellow_cones[1]]
+
+
+def create_marker_array(ordered_cones: List[List[float]], marker_array: MarkerArray, init: int=0) -> MarkerArray:
+    red = Color("red")
+    blue = Color("blue")
+    col_range = list(blue.range_to(red, len(ordered_cones)))
+
+    for i, cone in enumerate(ordered_cones):
+        marker = Marker()
+        marker.header.frame_id = "track"
+        marker.id = i+init
+        marker.type = Marker.CYLINDER
+        marker.action = Marker.ADD
+        marker.pose.position.x = cone[0]
+        marker.pose.position.y = cone[1]
+        marker.pose.position.z = 0.0
+        marker.scale.x = 0.5
+        marker.scale.y = 0.5
+        marker.scale.z = 1.0
+        marker.color = ColorRGBA(r=col_range[i].rgb[0], g=col_range[i].rgb[1], b=col_range[i].rgb[2], a=1.0)
+        marker_array.markers.append(marker)
+
+    return marker_array
+
 class OrderedMapSpline(Node):
     spline_const = 10  # number of points per cone
     segment = int(spline_const * 0.1)  # percentage of PPC
@@ -135,6 +181,7 @@ class OrderedMapSpline(Node):
         # publishers
         self.qutms_path_pub: Publisher = self.create_publisher(QUTMSPathStamped, "/planner/path", 1)
         self.spline_path_pub: Publisher = self.create_publisher(Path, "/planner/spline_path", 1)
+        self.marker_pub: Publisher = self.create_publisher(MarkerArray, "/markers/ordered_cones", 1)
 
         self.get_logger().info("---Ordered path planner node initalised---")
 
@@ -166,7 +213,7 @@ class OrderedMapSpline(Node):
             elif cone.color == Cone.ORANGE_BIG:
                 oranges.append([cone.location.x, cone.location.y])
 
-        parsed_orange_cones = self.parse_orange_cones(oranges)
+        parsed_orange_cones = parse_orange_cones(self.get_logger(), oranges)
         if len(parsed_orange_cones) == 0:
             return
         blues.insert(0, parsed_orange_cones[1])
@@ -177,6 +224,12 @@ class OrderedMapSpline(Node):
         # Sort the blue and yellow cones starting from the far orange cone, and ending at the close orange cone.
         ordered_blues = sort_cones(blues)
         ordered_yellows = sort_cones(yellows)
+
+        # create marker array for rviz with colours in order
+        marker_array = MarkerArray()
+        marker_array = create_marker_array(ordered_blues, marker_array)
+        marker_array = create_marker_array(ordered_yellows, marker_array, len(ordered_blues))
+        self.marker_pub.publish(marker_array)
 
         ## Spline smoothing
         # make number of pts based on length of path
@@ -257,27 +310,6 @@ class OrderedMapSpline(Node):
         qutms_path_msg = QUTMSPathStamped(path=qutms_path)
         qutms_path_msg.header.frame_id = "track"
         self.qutms_path_pub.publish(qutms_path_msg)
-
-    def parse_orange_cones(self, orange_cones: List[List[float]]) -> List[List[float]]:
-        """
-        Breaks the big orange starting cones into their position relative to the other blue/yellow cones.
-        Returns format close_blue, far_blue, close_yellow, far_yellow.
-        """
-        if len(orange_cones) != 4:
-            self.get_logger().fatal("parse_orange_cones called with less than 4 visible cones. Requires 4 cones.")
-            return []
-
-        blue_cones = [cone for cone in orange_cones if cone[1] > 0]
-        yellow_cones = [cone for cone in orange_cones if cone[1] < 0]
-
-        if blue_cones[0][0] > blue_cones[1][0]:
-            blue_cones[0], blue_cones[1] = blue_cones[1], blue_cones[0]
-
-        if yellow_cones[0][0] > yellow_cones[1][0]:
-            yellow_cones[0], yellow_cones[1] = yellow_cones[1], yellow_cones[0]
-
-        return [blue_cones[0], blue_cones[1], yellow_cones[0], yellow_cones[1]]
-
 
 def main(args=None):
     # begin ros node

--- a/src/navigation/py_slam/py_slam/node_odom_slam.py
+++ b/src/navigation/py_slam/py_slam/node_odom_slam.py
@@ -44,7 +44,7 @@ class OdomSlam(Node):
     discovered = False
 
     def __init__(self):
-        super().__init__("sbg_slam_node")
+        super().__init__("odom_slam_node")
 
         self.create_timer((1 / 50), self.timer_callback)  # 50hz state 'prediction'
 
@@ -133,7 +133,7 @@ class OdomSlam(Node):
         if self.last_odom_pose is None:
             return
 
-        if not self.mapping:
+        if not self.discovered and not self.mapping:
             return
 
         start: float = time.perf_counter()

--- a/src/operations/mission_controller/launch/trackdrive.launch.py
+++ b/src/operations/mission_controller/launch/trackdrive.launch.py
@@ -27,14 +27,14 @@ def generate_launch_description():
                 package="planners",
                 executable="ordered_mid_spline",
             ),
+            # IncludeLaunchDescription(
+            #     PythonLaunchDescriptionSource(
+            #         os.path.join(nav_package_share, "launch", "cone_association_slam.launch.py")
+            #     )
+            # ),
             IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    os.path.join(nav_package_share, "launch", "cone_association_slam.launch.py")
-                ),
-                launch_arguments={
-                    "slam_params_file": os.path.join(nav_package_share, "config/slam_params.yaml")
-                }.items(),
-            )
+                PythonLaunchDescriptionSource(os.path.join(nav_package_share, "launch", "odom_slam.launch.py"))
+            ),
             # Node(
             #     package="steering_actuator",
             #     executable="steering_actuator_node",

--- a/src/operations/mission_controller/launch/trackdrive.launch.py
+++ b/src/operations/mission_controller/launch/trackdrive.launch.py
@@ -27,14 +27,14 @@ def generate_launch_description():
                 package="planners",
                 executable="ordered_mid_spline",
             ),
-            # IncludeLaunchDescription(
-            #     PythonLaunchDescriptionSource(
-            #         os.path.join(nav_package_share, "launch", "cone_association_slam.launch.py")
-            #     ),
-            #     launch_arguments={
-            #         "slam_params_file": os.path.join(nav_package_share, "config/slam_params.yaml")
-            #     }.items(),
-            # )
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    os.path.join(nav_package_share, "launch", "cone_association_slam.launch.py")
+                ),
+                launch_arguments={
+                    "slam_params_file": os.path.join(nav_package_share, "config/slam_params.yaml")
+                }.items(),
+            )
             # Node(
             #     package="steering_actuator",
             #     executable="steering_actuator_node",

--- a/src/operations/mission_controller/mission_controller/node_mission_launcher.py
+++ b/src/operations/mission_controller/mission_controller/node_mission_launcher.py
@@ -6,6 +6,7 @@ from rclpy.node import Node
 from driverless_msgs.msg import State
 
 from driverless_common.status_constants import INT_MISSION_TYPE
+from driverless_common.common import QOS_LATEST
 
 
 class MissionControl(Node):
@@ -15,12 +16,12 @@ class MissionControl(Node):
     def __init__(self):
         super().__init__("mission_control_node")
 
-        self.create_subscription(State, "/system/as_status", self.callback, 10)
+        self.create_subscription(State, "/system/as_status", self.callback, QOS_LATEST)
 
         self.get_logger().info("---Mission control node initialised---")
 
     def callback(self, status: State):
-        if status.mission != State.MISSION_NONE:
+        if status.mission != State.MISSION_NONE and not self.mission_launched:
             target_mission = INT_MISSION_TYPE[status.mission].value
             launch_file = target_mission + ".launch.py"
             command = ["stdbuf", "-o", "L", "ros2", "launch", "mission_controller", launch_file]

--- a/src/operations/mission_controller/mission_controller/node_mission_launcher.py
+++ b/src/operations/mission_controller/mission_controller/node_mission_launcher.py
@@ -4,7 +4,6 @@ import rclpy
 from rclpy.node import Node
 
 from driverless_msgs.msg import State
-from std_msgs.msg import UInt8
 
 from driverless_common.status_constants import INT_MISSION_TYPE
 
@@ -17,30 +16,18 @@ class MissionControl(Node):
         super().__init__("mission_control_node")
 
         self.create_subscription(State, "/system/as_status", self.callback, 10)
-        self.create_subscription(UInt8, "/system/mission_select", self.select_callback, 10)
 
         self.get_logger().info("---Mission control node initialised---")
 
     def callback(self, status: State):
-        if status.state == State.SELECT_MISSION:
-            self.mission_launched = False
-        if status.mission != State.MISSION_NONE and not self.mission_launched:
-            self.launch_mission(status.mission)
-
-    def select_callback(self, msg: UInt8):
-        if msg.data == State.MISSION_NONE:
-            self.mission_launched = False
-        if msg.data != State.MISSION_NONE and not self.mission_launched:
-            self.launch_mission(msg.data)
-
-    def launch_mission(self, mission_id: int):
-        target_mission = INT_MISSION_TYPE[mission_id].value
-        launch_file = target_mission + ".launch.py"
-        command = ["stdbuf", "-o", "L", "ros2", "launch", "mission_controller", launch_file]
-        self.get_logger().info(f"Command: {' '.join(command)}")
-        self.process = Popen(command)
-        self.get_logger().info("Mission started: " + target_mission)
-        self.mission_launched = True
+        if status.mission != State.MISSION_NONE:
+            target_mission = INT_MISSION_TYPE[status.mission].value
+            launch_file = target_mission + ".launch.py"
+            command = ["stdbuf", "-o", "L", "ros2", "launch", "mission_controller", launch_file]
+            self.get_logger().info(f"Command: {' '.join(command)}")
+            self.process = Popen(command)
+            self.get_logger().info("Mission started: " + target_mission)
+            self.mission_launched = True
 
 
 def main(args=None):

--- a/src/operations/mission_controller/mission_controller/node_mission_launcher.py
+++ b/src/operations/mission_controller/mission_controller/node_mission_launcher.py
@@ -21,7 +21,7 @@ class MissionControl(Node):
         self.get_logger().info("---Mission control node initialised---")
 
     def callback(self, status: State):
-        if status.mission != State.MISSION_NONE and not self.mission_launched:
+        if status.mission != State.MISSION_NONE and status.state != State.EMERGENCY and not self.mission_launched:
             target_mission = INT_MISSION_TYPE[status.mission].value
             launch_file = target_mission + ".launch.py"
             command = ["stdbuf", "-o", "L", "ros2", "launch", "mission_controller", launch_file]

--- a/src/operations/mission_controller/mission_controller/node_mission_launcher.py
+++ b/src/operations/mission_controller/mission_controller/node_mission_launcher.py
@@ -5,8 +5,8 @@ from rclpy.node import Node
 
 from driverless_msgs.msg import State
 
-from driverless_common.status_constants import INT_MISSION_TYPE
 from driverless_common.common import QOS_LATEST
+from driverless_common.status_constants import INT_MISSION_TYPE
 
 
 class MissionControl(Node):

--- a/src/operations/mission_controller/mission_controller/node_trackdrive_handler.py
+++ b/src/operations/mission_controller/mission_controller/node_trackdrive_handler.py
@@ -4,22 +4,22 @@ import rclpy
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 
-from driverless_msgs.msg import Reset, Shutdown
+from driverless_msgs.msg import State, Shutdown
 from geometry_msgs.msg import PoseWithCovarianceStamped
-from std_msgs.msg import Bool, UInt8
+from std_msgs.msg import UInt8
 
 from driverless_common.shutdown_node import ShutdownNode
 
 
 class TrackdriveHandler(ShutdownNode):
-    r2d = False
+    mission_started = False
     laps = 0
     last_lap_time = 0.0
     last_x = 0.0
 
     def __init__(self):
         super().__init__("trackdrive_logic_node")
-        self.create_subscription(Bool, "/system/r2d", self.r2d_callback, 10)
+        self.create_subscription(State, "/system/as_status", self.state_callback, 10)
         self.create_subscription(PoseWithCovarianceStamped, "/slam/car_pose", self.pose_callback, 10)
 
         self.shutdown_pub = self.create_publisher(Shutdown, "/system/shutdown", 1)
@@ -27,17 +27,18 @@ class TrackdriveHandler(ShutdownNode):
 
         self.get_logger().info("---Trackdrive handler node initialised---")
 
-    def r2d_callback(self, msg: Bool):
-        if not self.r2d and msg.data:
-            self.r2d = True
+    def state_callback(self, msg: State):
+        if not self.mission_started and msg.state == State.DRIVING and msg.mission == State.TRACKDRIVE:
+            self.mission_started = True
             self.last_lap_time = time.time()
+            self.lap_trig_pub.publish(UInt8(data=self.laps))
             self.get_logger().info("Trackdrive mission started")
 
     def pose_callback(self, msg: PoseWithCovarianceStamped):
         # check if car has crossed the finish line (0,0)
         # get distance from 0,0 and increment laps when within a certain threshold
         # and distance is increasing away from 0,0
-        if self.r2d and (self.last_x <= 0 and msg.pose.pose.position.x > 0) and abs(msg.pose.pose.position.y) < 2:
+        if self.mission_started and (self.last_x <= 0 and msg.pose.pose.position.x > 0) and abs(msg.pose.pose.position.y) < 2:
             if time.time() - self.last_lap_time > 20:  # 20 seconds at least between laps
                 self.laps += 1
                 self.last_lap_time = time.time()

--- a/src/operations/mission_controller/mission_controller/node_trackdrive_handler.py
+++ b/src/operations/mission_controller/mission_controller/node_trackdrive_handler.py
@@ -4,7 +4,7 @@ import rclpy
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 
-from driverless_msgs.msg import State, Shutdown
+from driverless_msgs.msg import Shutdown, State
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from std_msgs.msg import UInt8
 
@@ -38,7 +38,11 @@ class TrackdriveHandler(ShutdownNode):
         # check if car has crossed the finish line (0,0)
         # get distance from 0,0 and increment laps when within a certain threshold
         # and distance is increasing away from 0,0
-        if self.mission_started and (self.last_x <= 0 and msg.pose.pose.position.x > 0) and abs(msg.pose.pose.position.y) < 2:
+        if (
+            self.mission_started
+            and (self.last_x <= 0 and msg.pose.pose.position.x > 0)
+            and abs(msg.pose.pose.position.y) < 2
+        ):
             if time.time() - self.last_lap_time > 20:  # 20 seconds at least between laps
                 self.laps += 1
                 self.last_lap_time = time.time()


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide evidence of tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimisation

## [required] Description

Expanded the supervisor state to include lap counter field. 
Rather than have each processing node subscribe to the ‘counter’, ‘ready-to-drive’, and ‘state’ topics, this would consolidate these through a single signal monitor - vehicle supervisor.

## [required] Documentation

Rev C added to: `Driverless/Documentation/Software/Infrastructure/Vehicle State Control` 

### [optional] Usability concerns or breaking changes?

Aligns with our new simulator state interface so that it can work optimally. Running the new interface requires this addition to extract the most out of it.
REQUIRED: the mission launcher now starts a ROS 2 launch file from a different repo which is for better mapping packages: https://github.com/b1n-ch1kn/QUTMS_Nav_Integration
Clone into the `~/QUTMS/` folder - next to this repo and the sim.
Then follow the install instructions to install dependencies in the Readme.

### [optional] Screenshots
