### PR TITLE
Pure pursuit cpp update

### DIFF
--- a/src/control/pure_pursuit_cpp/CMakeLists.txt
+++ b/src/control/pure_pursuit_cpp/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rclcpp REQUIRED)
 find_package(ackermann_msgs REQUIRED)
 find_package(driverless_msgs REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 SET_SOURCE_FILES_PROPERTIES(${SOURCES} PROPERTIES LANGUAGE CXX)
 
@@ -22,7 +23,8 @@ ament_target_dependencies(pure_pursuit_cpp
         rclcpp
         driverless_msgs
         ackermann_msgs
-        tf2)
+        tf2
+        tf2_ros)
 
 target_include_directories(pure_pursuit_cpp PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/control/pure_pursuit_cpp/package.xml
+++ b/src/control/pure_pursuit_cpp/package.xml
@@ -11,6 +11,7 @@
     <depend>driverless_msgs</depend>
     <depend>ackermann_msgs</depend>
     <depend>tf2</depend>
+    <depend>tf2_ros</depend>
 
     <export>
         <build_type>ament_cmake</build_type>

--- a/src/control/pure_pursuit_cpp/src/node_pure_pursuit_cpp.cpp
+++ b/src/control/pure_pursuit_cpp/src/node_pure_pursuit_cpp.cpp
@@ -1,5 +1,7 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <chrono>
 
@@ -34,9 +36,13 @@ class PurePursuit : public rclcpp::Node {
    private:
     rclcpp::Subscription<driverless_msgs::msg::PathStamped>::SharedPtr path_sub;
     rclcpp::Subscription<driverless_msgs::msg::State>::SharedPtr state_sub;
-    rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr slam_pose_sub;
     rclcpp::Publisher<ackermann_msgs::msg::AckermannDriveStamped>::SharedPtr driving_command_pub;
+    rclcpp::TimerBase::SharedPtr timer;
     std::vector<Point> path{};
+
+    tf2_ros::Buffer buffer;
+    tf2_ros::TransformListener listener;
+
     double lookahead;
     double squared_lookahead;  // allows us to skip performing sqrts in get_rvwp()
     double kp_ang;
@@ -137,18 +143,38 @@ class PurePursuit : public rclcpp::Node {
         fallback_path_points_offset = round(path.size() / distance * lookahead);
     }
 
-    void pose_callback(geometry_msgs::msg::PoseWithCovarianceStamped const& pose_msg) {
-        if (path.empty()) return;
+    void transform_callback() {
+        // Listens to odom->base_footprint transform and updates the state.
+        // Solution is to get the delta and add it to the previous state and subtract the delta from the previous
+        // map->odom transform.
+        if (!following || !driving || path.empty()) {
+            started = false;
+            return;
+        }
+
+        if (!started) {
+            started = true;
+            RCLCPP_INFO(get_logger(), "Starting pure pursuit (C++)");
+        }
+
         auto start_time = std::chrono::high_resolution_clock::now();
 
-        tf2::Quaternion q(pose_msg.pose.pose.orientation.x, pose_msg.pose.pose.orientation.y,
-                          pose_msg.pose.pose.orientation.z, pose_msg.pose.pose.orientation.w);
+        geometry_msgs::msg::TransformStamped odom_to_base;
+        try {
+            odom_to_base = buffer.lookupTransform("track", "base_footprint", tf2::TimePointZero);
+        } catch (tf2::TransformException const& e) {
+            RCLCPP_WARN(get_logger(), "Transform Exception: %s", e.what());
+            return;
+        }
+
+        tf2::Quaternion q(odom_to_base.transform.rotation.x, odom_to_base.transform.rotation.y,
+                          odom_to_base.transform.rotation.z, odom_to_base.transform.rotation.w);
         tf2::Matrix3x3 m(q);
         double roll, pitch, yaw;
         m.getRPY(roll, pitch, yaw);
 
-        double position_cog_x = pose_msg.pose.pose.position.x;
-        double position_cog_y = pose_msg.pose.pose.position.y;
+        double position_cog_x = odom_to_base.transform.translation.x;
+        double position_cog_y = odom_to_base.transform.translation.y;
         Pose car_axle_position = calc_car_axle_pos(position_cog_x, position_cog_y, yaw);
         Point rvwp = get_rvwp(car_axle_position);
 
@@ -177,13 +203,16 @@ class PurePursuit : public rclcpp::Node {
             "/planner/path", QOS_LATEST, std::bind(&PurePursuit::path_callback, this, _1));
         this->state_sub = this->create_subscription<driverless_msgs::msg::State>(
             "/system/as_status", QOS_LATEST, std::bind(&PurePursuit::state_callback, this, _1));
+        timer =
+            this->create_wall_timer(std::chrono::milliseconds(20), std::bind(&PurePursuit::transform_callback, this));
 
         this->driving_command_pub =
             this->create_publisher<ackermann_msgs::msg::AckermannDriveStamped>("/control/driving_command", 10);
 
-        this->target_velocity = this->declare_parameter<double>("target_velocity", 10.0);
+        this->vel_max = this->declare_parameter<double>("vel_max", 10.0);
+        this->vel_min = this->declare_parameter<double>("vel_min", 4.0);
         this->kp_ang = this->declare_parameter<double>("kp_ang", -3.0);
-        this->lookahead = this->declare_parameter<double>("lookahead", 3.0);
+        this->lookahead = this->declare_parameter<double>("lookahead", 3);
         squared_lookahead = lookahead * lookahead;
         RCLCPP_INFO(get_logger(), "---Pure Pursuit (C++) Node Initialised---");
     }

--- a/src/control/pure_pursuit_cpp/src/node_pure_pursuit_cpp.cpp
+++ b/src/control/pure_pursuit_cpp/src/node_pure_pursuit_cpp.cpp
@@ -46,7 +46,8 @@ class PurePursuit : public rclcpp::Node {
     double lookahead;
     double squared_lookahead;  // allows us to skip performing sqrts in get_rvwp()
     double kp_ang;
-    double target_velocity;
+    double vel_max;
+    double vel_min;
     int fallback_path_points_offset;  // The number of path points to be skipped for an approximate rvwp
 
     // Internal states
@@ -182,9 +183,12 @@ class PurePursuit : public rclcpp::Node {
         double error = wrap_to_pi(yaw - desired_heading_angle);
         double steering_angle = (error * (180 / M_PI)) * kp_ang;
 
+        double velocity =
+            vel_min + std::max((vel_max - vel_min) * (1 - std::pow((std::abs(steering_angle) / 90), 2)), 0.0);
+
         ackermann_msgs::msg::AckermannDriveStamped driving_command;
         driving_command.header.stamp = now();
-        driving_command.drive.speed = target_velocity;
+        driving_command.drive.speed = velocity;
         driving_command.drive.steering_angle = steering_angle;
         this->driving_command_pub->publish(driving_command);
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
Refactor.

## Description
Copying improvements @Grant-ed made to the python pure pursuit implementation over to the C++ implementation. Also using the new state system.

## Documentation
N/a

### Usability concerns or breaking changes?
For some reason, the `lookahead` distance of `6.0` used in the Grant's PR doesn't work with the C++, or the KDTree implementation, the car cuts corners and hits cones. 
