### PR TITLE
Socketcan

### DIFF
--- a/docker/Dockerfile.roscube
+++ b/docker/Dockerfile.roscube
@@ -11,7 +11,7 @@ WORKDIR /tmp
 # installs for controllers?
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        libgl1-mesa-glx \
+        libgl1-mesa-glx can-utils net-tools \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/docker/roscube_startup.sh
+++ b/docker/roscube_startup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd /home/qutms/dev/repos/QUTMS_Driverless/docker
+make run target=roscube
+
+### THIS SCRIPT IS CALLED BY A ROSCUBE STARTUP SERVICE ###
+### FOUND IN /etc/systemd/system/roscube_startup.service ###
+# [Unit]
+# Description=Run Roscube Startup Service as user qutms
+# DefaultDependencies=no
+# After=network.target
+
+# [Service]
+# Type=simple
+# User=qutms
+# Group=qutms
+# ExecStart=/home/qutms/dev/repos/QUTMS_Driverless/docker/roscube_startup.sh
+# TimeoutStartSec=0
+# RemainAfterExit=yes
+
+# [Install]
+# WantedBy=default.target

--- a/src/hardware/canbus/CMakeLists.txt
+++ b/src/hardware/canbus/CMakeLists.txt
@@ -43,8 +43,22 @@ target_include_directories(canbus_translator_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
+add_executable(canbus_translator_socket_node src/node_canbus_translator_socket.cpp ${SOURCES})
+ament_target_dependencies(canbus_translator_socket_node rclcpp driverless_msgs nav_msgs std_msgs)
+target_include_directories(canbus_translator_socket_node PUBLIC include PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
+target_include_directories(canbus_translator_socket_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
+add_executable(canbus_node src/node_canbus.cpp ${SOURCES})
+ament_target_dependencies(canbus_node rclcpp driverless_msgs nav_msgs std_msgs)
+target_include_directories(canbus_node PUBLIC include PUBLIC ${CMAKE_SOURCE_DIR}/../../common/driverless_common/include)
+target_include_directories(canbus_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
 install(TARGETS
-  canbus_translator_node
+  canbus_translator_node canbus_translator_socket_node canbus_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/src/hardware/canbus/CMakeLists.txt
+++ b/src/hardware/canbus/CMakeLists.txt
@@ -28,6 +28,7 @@ set (SOURCES
   src/tcp_client.cpp
   src/udp_client.cpp
   src/TritiumCAN.cpp
+  src/SocketCAN.cpp
   ${CMAKE_SOURCE_DIR}/../../hardware/QUTMS_Embedded_Common/Src/CAN_VCU.c
   ${CMAKE_SOURCE_DIR}/../../hardware/QUTMS_Embedded_Common/Src/CAN_VESC.c
   ${CMAKE_SOURCE_DIR}/../../hardware/QUTMS_Embedded_Common/Src/CAN_BMU.c

--- a/src/hardware/canbus/config/canbus.yaml
+++ b/src/hardware/canbus/config/canbus.yaml
@@ -2,4 +2,5 @@ canbus_translator_node:
   ros__parameters:
       ip: "192.168.2.125"
       port: 20005
+      interface: "can0"
       base_frame: "base_footprint"

--- a/src/hardware/canbus/include/SocketCAN.hpp
+++ b/src/hardware/canbus/include/SocketCAN.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "driverless_msgs/msg/can.hpp"
+
+const int SCAN_RECV_SIZE = 4096;
+
+class SocketCAN {
+   private:
+    bool isConnected;
+    int sock;
+    uint8_t rxBuf[SCAN_RECV_SIZE];
+
+   public:
+    SocketCAN();
+
+    bool setup(std::string interface);
+
+    void tx(driverless_msgs::msg::Can *msg);
+    std::shared_ptr<std::vector<driverless_msgs::msg::Can>> rx();
+
+    void compose_socketcan_frame(driverless_msgs::msg::Can *msg, struct can_frame *frame);
+    bool parse_socketcan_frame(struct can_frame *frame, driverless_msgs::msg::Can *msg);
+
+    ~SocketCAN();
+};

--- a/src/hardware/canbus/src/SocketCAN.cpp
+++ b/src/hardware/canbus/src/SocketCAN.cpp
@@ -11,9 +11,14 @@
 
 #include <iostream>
 
-SocketCAN::SocketCAN() { this->isConnected = false; }
+SocketCAN::SocketCAN() { 
+    this->isConnected = false; 
+    this->sock = -1;
+}
 
 bool SocketCAN::setup(std::string interface) {
+    std::cout << "CAN - Socket already attached on: " << this->sock << std::endl;
+
     // create socket
     if (this->sock == -1) {
         this->sock = socket(PF_CAN, SOCK_RAW, CAN_RAW);

--- a/src/hardware/canbus/src/SocketCAN.cpp
+++ b/src/hardware/canbus/src/SocketCAN.cpp
@@ -1,0 +1,125 @@
+#include "SocketCAN.hpp"
+
+#include <ifaddrs.h>
+#include <linux/can.h>
+#include <net/if.h>
+#include <netdb.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iostream>
+
+SocketCAN::SocketCAN() { this->isConnected = false; }
+
+bool SocketCAN::setup(std::string interface) {
+    // create socket
+    if (this->sock == -1) {
+        this->sock = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+        if (this->sock == -1) {
+            std::cout << "CAN - Failed to create socket." << std::endl;
+            return false;
+        }
+    }
+
+    // get interface index
+    struct ifreq ifr;
+    strcpy(ifr.ifr_name, interface.c_str());
+    ioctl(this->sock, SIOCGIFINDEX, &ifr);
+
+    // bind socket to interface
+    struct sockaddr_can addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.can_family = AF_CAN;
+    addr.can_ifindex = ifr.ifr_ifindex;
+    if (bind(this->sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        std::cout << "CAN - Failed to bind interface to socket." << std::endl;
+        return false;
+    }
+
+    this->isConnected = true;
+    return true;
+}
+
+void SocketCAN::compose_socketcan_frame(driverless_msgs::msg::Can *msg, struct can_frame *frame) {
+    frame->can_id = msg->id;
+    if (msg->id_type) {
+        // set extended bit
+        frame->can_id |= CAN_EFF_FLAG;
+    }
+
+    frame->can_dlc = msg->dlc;
+    for (uint8_t i = 0; i < msg->dlc; i++) {
+        frame->data[i] = msg->data.data()[i];
+    }
+}
+
+bool SocketCAN::parse_socketcan_frame(struct can_frame *frame, driverless_msgs::msg::Can *msg) {
+    msg->id_type = (frame->can_id & CAN_EFF_FLAG) != 0;
+
+    if (msg->id_type != 0) {
+        msg->id = frame->can_id & CAN_EFF_MASK;
+    } else {
+        msg->id = frame->can_id & CAN_SFF_MASK;
+    }
+
+    msg->dlc = frame->can_dlc;
+    std::vector<uint8_t> msgData;
+    for (uint8_t i = 0; i < msg->dlc; i++) {
+        msgData.push_back(frame->data[i]);
+    }
+    msg->data = msgData;
+
+    return true;
+}
+
+void SocketCAN::tx(driverless_msgs::msg::Can *msg) {
+    if (this->isConnected) {
+        struct can_frame frame;
+        compose_socketcan_frame(msg, &frame);
+
+        if (write(this->sock, &frame, sizeof(struct can_frame)) != sizeof(struct can_frame)) {
+            std::cout << "CAN - Failed TX." << std::endl;
+        }
+    }
+}
+
+std::shared_ptr<std::vector<driverless_msgs::msg::Can>> SocketCAN::rx() {
+    auto msgs = std::make_shared<std::vector<driverless_msgs::msg::Can>>();
+    driverless_msgs::msg::Can rxMsg;
+
+    if (this->isConnected) {
+        // only need to try Rx if we're connected
+        // this function polls the socket for data, but will block if there's no data to recieve
+        // can't know ahead of time how many messages to read, so will just read to oversized buffer
+
+        // use DONTWAIT flag to make this non blocking
+        ssize_t rxLen = recv(this->sock, this->rxBuf, SCAN_RECV_SIZE, MSG_DONTWAIT);
+
+        if (rxLen > 0) {
+            size_t len = rxLen;
+            for (size_t offset = 0; offset < len; offset += sizeof(struct can_frame)) {
+                if ((offset + sizeof(struct can_frame)) <= len) {
+                    // there is a full frame here, read it
+
+                    // convert appropriate bytes from socket into a can_frame
+                    struct can_frame *frame = (struct can_frame *)&(this->rxBuf[offset]);
+                    if (parse_socketcan_frame(frame, &rxMsg)) {
+                        msgs->push_back(rxMsg);
+                    }
+                }
+            }
+        }
+    }
+
+    return msgs;
+}
+
+SocketCAN::~SocketCAN() {
+    if (this->sock != -1) {
+        close(this->sock);
+        this->isConnected = false;
+        this->sock = -1;
+    }
+}

--- a/src/hardware/canbus/src/SocketCAN.cpp
+++ b/src/hardware/canbus/src/SocketCAN.cpp
@@ -11,8 +11,8 @@
 
 #include <iostream>
 
-SocketCAN::SocketCAN() { 
-    this->isConnected = false; 
+SocketCAN::SocketCAN() {
+    this->isConnected = false;
     this->sock = -1;
 }
 

--- a/src/hardware/canbus/src/node_canbus_translator.cpp
+++ b/src/hardware/canbus/src/node_canbus_translator.cpp
@@ -86,7 +86,7 @@ class CanBus : public rclcpp::Node {
             if (std::find(can_ids.begin(), can_ids.end(), msg.id) != can_ids.end()) {
                 RCLCPP_INFO(this->get_logger(), "CAN message received from %i", msg.id & 0xF);
                 this->can_pub_->publish(msg);
-            } 
+            }
             if (qutms_masked_id == VCU_Heartbeat_ID || qutms_masked_id == SW_Heartbeat_ID) {
                 RCLCPP_INFO(this->get_logger(), "Heartbeat received from %i", msg.id & 0xF);
                 this->can_pub_->publish(msg);
@@ -138,7 +138,7 @@ class CanBus : public rclcpp::Node {
                 Parse_VCU_TransmitSteering(data, &steering_0_raw, &steering_1_raw, &adc_0, &adc_1);
                 // Log steering angle
                 RCLCPP_INFO(this->get_logger(), "Steering Angle 0: %i  Steering Angle 1: %i ADC 0: %i ADC 1: %i",
-                             steering_0_raw, steering_1_raw, adc_0, adc_1);
+                            steering_0_raw, steering_1_raw, adc_0, adc_1);
                 double steering_0 = steering_0_raw / 10.0;
                 double steering_1 = steering_1_raw / 10.0;
 
@@ -150,8 +150,9 @@ class CanBus : public rclcpp::Node {
                     last_steering_angle = steering_0;
                     // update_odom();
                 } else {
-                    RCLCPP_FATAL(this->get_logger(), "MISMATCH: Steering Angle 0: %i  Steering Angle 1: %i ADC 0: %i ADC 1: %i",
-                             steering_0_raw, steering_1_raw, adc_0, adc_1);
+                    RCLCPP_FATAL(this->get_logger(),
+                                 "MISMATCH: Steering Angle 0: %i  Steering Angle 1: %i ADC 0: %i ADC 1: %i",
+                                 steering_0_raw, steering_1_raw, adc_0, adc_1);
                 }
             }
             // BMU
@@ -211,7 +212,7 @@ class CanBus : public rclcpp::Node {
         this->odom_pub_ = this->create_publisher<nav_msgs::msg::Odometry>("/vehicle/wheel_odom", 10);
         // BMU
         this->bmu_status_pub_ = this->create_publisher<driverless_msgs::msg::CarStatus>("/vehicle/bmu_status", 10);
-        
+
         this->bmu_status.brick_data = std::vector<driverless_msgs::msg::BrickData>(NUM_CMUS);
         for (int i = 0; i < NUM_CMUS; i++) {
             this->bmu_status.brick_data[i].id = i + 1;

--- a/src/hardware/canbus/src/node_canbus_translator_socket.cpp
+++ b/src/hardware/canbus/src/node_canbus_translator_socket.cpp
@@ -15,7 +15,7 @@
 #include "driverless_msgs/msg/car_status.hpp"
 #include "driverless_msgs/msg/res.hpp"
 #include "driverless_msgs/msg/wss_velocity.hpp"
-#include "nav_msgs/msg/odometry.hpp"
+#include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/bool.hpp"
 #include "std_msgs/msg/float32.hpp"
@@ -56,7 +56,9 @@ class CanBus : public rclcpp::Node {
     rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr steering_angle_pub_;
     rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr velocity_pub_;
     rclcpp::Publisher<driverless_msgs::msg::CarStatus>::SharedPtr bmu_status_pub_;
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr twist_pub_;
+
+    std::string ros_base_frame_;
 
     // can connection
     std::shared_ptr<SocketCAN> socketCAN;
@@ -64,17 +66,18 @@ class CanBus : public rclcpp::Node {
     // class variables for sensor data
     float wheel_speeds[4];
     driverless_msgs::msg::CarStatus bmu_status;
-    nav_msgs::msg::Odometry odom_msg;
+    geometry_msgs::msg::TwistWithCovarianceStamped twist_msg;
     float last_velocity;
     float last_steering_angle;
 
-    void update_odom() {
-        // use last velocity and steering angle to update odom
-        odom_msg.header.stamp = this->now();
-        odom_msg.twist.twist.linear.x = last_velocity;
-        odom_msg.twist.twist.linear.y = 0.0;
-        odom_msg.twist.twist.angular.z = last_velocity * tan(last_steering_angle) / AXLE_WIDTH;
-        odom_pub_->publish(odom_msg);
+    void update_twist() {
+        // use last velocity and steering angle to update twist
+        twist_msg.header.stamp = this->now();
+        twist_msg.header.frame_id = ros_base_frame_;  // PARAMETERISE
+        twist_msg.twist.twist.linear.x = last_velocity;
+        twist_msg.twist.twist.linear.y = 0.0;
+        twist_msg.twist.twist.angular.z = last_velocity * tan(last_steering_angle) / AXLE_WIDTH;
+        twist_pub_->publish(twist_msg);
     }
 
     void canmsg_timer() {
@@ -116,8 +119,8 @@ class CanBus : public rclcpp::Node {
                     last_velocity = av_velocity;
                     this->velocity_pub_->publish(vel_msg);
 
-                    // update odom msg with new velocity
-                    update_odom();
+                    // update twist msg with new velocity
+                    update_twist();
                 }
             }
             // Steering Angle
@@ -142,7 +145,9 @@ class CanBus : public rclcpp::Node {
                 if (abs(steering_0 - steering_1) < 10) {
                     angle_msg.data = steering_0;
                     last_steering_angle = steering_0;
-                    update_odom();
+
+                    // update twist msg with new steering angle
+                    update_twist();
                 } else {
                     angle_msg.data = 1111.0;  // error identifier (impossible value)
                 }
@@ -179,7 +184,9 @@ class CanBus : public rclcpp::Node {
     CanBus() : Node("canbus_translator_node") {
         // socketCAN parameters
         std::string _interface = this->declare_parameter<std::string>("interface", "can0");
+        ros_base_frame_ = this->declare_parameter<std::string>("base_frame", "base_link");
         this->get_parameter("interface", _interface);
+        this->get_parameter("base_frame", ros_base_frame_);
 
         RCLCPP_INFO(this->get_logger(), "Creating Connection on %s...", _interface.c_str());
         this->socketCAN = std::make_shared<SocketCAN>();
@@ -199,8 +206,9 @@ class CanBus : public rclcpp::Node {
         this->steering_angle_pub_ = this->create_publisher<std_msgs::msg::Float32>("/vehicle/steering_angle", 10);
         // Vehicle velocity
         this->velocity_pub_ = this->create_publisher<std_msgs::msg::Float32>("/vehicle/velocity", 10);
-        // Odometry
-        this->odom_pub_ = this->create_publisher<nav_msgs::msg::Odometry>("/vehicle/wheel_odom", 10);
+        // Twist
+        this->twist_pub_ =
+            this->create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>("/vehicle/wheel_twist", 10);
         // BMU
         this->bmu_status_pub_ = this->create_publisher<driverless_msgs::msg::CarStatus>("/vehicle/bmu_status", 10);
         this->bmu_status.brick_data = std::vector<driverless_msgs::msg::BrickData>(NUM_CMUS);

--- a/src/hardware/canbus/src/node_canbus_translator_socket.cpp
+++ b/src/hardware/canbus/src/node_canbus_translator_socket.cpp
@@ -1,224 +1,224 @@
-#include <algorithm> 
-#include <bitset> 
-#include <iostream> 
- 
-#include "CAN_BMU.h" 
-#include "CAN_DVL.h" 
-#include "CAN_RES.h" 
-#include "CAN_SW.h" 
-#include "CAN_VCU.h" 
-#include "CAN_VESC.h" 
-#include "QUTMS_can.h" 
-#include "SocketCAN.hpp" 
-#include "driverless_common/common.hpp" 
-#include "driverless_msgs/msg/can.hpp" 
-#include "driverless_msgs/msg/car_status.hpp" 
-#include "driverless_msgs/msg/res.hpp" 
-#include "driverless_msgs/msg/wss_velocity.hpp" 
-#include "nav_msgs/msg/odometry.hpp" 
-#include "rclcpp/rclcpp.hpp" 
-#include "std_msgs/msg/bool.hpp" 
-#include "std_msgs/msg/float32.hpp" 
-#include "std_msgs/msg/u_int8.hpp" 
- 
-using std::placeholders::_1; 
- 
-const int NUM_CMUS = 8; 
-const int NUM_VOLTAGES = 14; 
-const int NUM_TEMPERATURES = 16; 
-const float WHEEL_DIAMETER = 0.4064; 
-const float AXLE_WIDTH = 1.4; 
- 
-void copy_data(const std::vector<uint8_t> &vec, uint8_t *dest, size_t n) { 
-    for (size_t i = 0; i < n; i++) { 
-        dest[i] = vec[i]; 
-    } 
-} 
- 
-// create array of CAN IDs we care about 
-std::vector<uint32_t> can_ids = { 
-    0x5F0,                  // C5_E stepper ID 
-    (0x700 + RES_NODE_ID),  // boot up message 
-    RES_Heartbeat_ID, 
-}; 
- 
-class CanBus : public rclcpp::Node { 
-   private: 
-    // can connection queue retrieval timer 
-    rclcpp::TimerBase::SharedPtr timer_; 
- 
-    // subscriber 
-    rclcpp::Subscription<driverless_msgs::msg::Can>::SharedPtr can_sub_; 
- 
-    // publishers 
-    rclcpp::Publisher<driverless_msgs::msg::Can>::SharedPtr can_pub_; 
-    // ADD PUBS FOR CAN TOPICS HERE 
-    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr steering_angle_pub_; 
-    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr velocity_pub_; 
-    rclcpp::Publisher<driverless_msgs::msg::CarStatus>::SharedPtr bmu_status_pub_; 
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_; 
- 
-    // can connection 
-    std::shared_ptr<SocketCAN> socketCAN; 
- 
-    // class variables for sensor data 
-    float wheel_speeds[4]; 
-    driverless_msgs::msg::CarStatus bmu_status; 
-    nav_msgs::msg::Odometry odom_msg; 
-    float last_velocity; 
-    float last_steering_angle; 
- 
-    void update_odom() { 
-        // use last velocity and steering angle to update odom 
-        odom_msg.header.stamp = this->now(); 
-        odom_msg.twist.twist.linear.x = last_velocity; 
-        odom_msg.twist.twist.linear.y = 0.0; 
-        odom_msg.twist.twist.angular.z = last_velocity * tan(last_steering_angle) / AXLE_WIDTH; 
-        odom_pub_->publish(odom_msg); 
-    } 
- 
-    void canmsg_timer() { 
-        auto res = this->socketCAN->rx(); 
- 
-        for (auto &msg : *res) { 
-            uint32_t qutms_masked_id = msg.id & ~0xF; 
-            // only publish can messages with IDs we care about to not flood memory 
-            if (std::find(can_ids.begin(), can_ids.end(), msg.id) != can_ids.end()) { 
-                this->can_pub_->publish(msg); 
-            } else if (qutms_masked_id == VCU_Heartbeat_ID || qutms_masked_id == SW_Heartbeat_ID) { 
-                this->can_pub_->publish(msg); 
-            } 
- 
-            // CAN TRANSLATION OPTIONS 
-            // Wheel speed velocity 
-            uint32_t vesc_masked_id = (msg.id & ~0xFF) >> 8; 
-            uint8_t vesc_id = msg.id & 0xFF; 
-            if (vesc_id < 4) { 
-                if (vesc_masked_id == VESC_CAN_PACKET_STATUS) { 
-                    uint8_t data[8]; 
-                    copy_data(msg.data, data, 8); 
-                    // extract and publish RPM 
-                    int32_t rpm; 
-                    float current; 
-                    float duty; 
-                    Parse_VESC_CANPacketStatus(data, &rpm, &current, &duty); 
- 
-                    wheel_speeds[vesc_id] = (rpm / (21.0 * 4.50)) * M_PI * WHEEL_DIAMETER / 60; 
-                    float av_velocity = 0; 
-                    for (int i = 0; i < 4; i++) { 
-                        av_velocity += this->wheel_speeds[i]; 
-                    } 
-                    av_velocity = av_velocity / 4; 
- 
-                    // publish velocity 
-                    std_msgs::msg::Float32 vel_msg; 
-                    vel_msg.data = av_velocity; 
-                    last_velocity = av_velocity; 
-                    this->velocity_pub_->publish(vel_msg); 
- 
-                    // update odom msg with new velocity 
-                    update_odom(); 
-                } 
-            } 
-            // Steering Angle 
-            else if (qutms_masked_id == VCU_TransmitSteering_ID) { 
-                // data vector to uint8_t array 
-                uint8_t data[8]; 
-                copy_data(msg.data, data, 8); 
- 
-                int16_t steering_0_raw; 
-                int16_t steering_1_raw; 
-                uint16_t adc_0; 
-                uint16_t adc_1; 
- 
-                Parse_VCU_TransmitSteering(data, &steering_0_raw, &steering_1_raw, &adc_0, &adc_1); 
-                // Log steering angle 
-                RCLCPP_DEBUG(this->get_logger(), "Steering Angle 0: %i  Steering Angle 1: %i ADC 0: %i ADC 1: %i", 
-                             steering_0_raw, steering_1_raw, adc_0, adc_1); 
-                double steering_0 = steering_0_raw / 10.0; 
-                double steering_1 = steering_1_raw / 10.0; 
- 
-                std_msgs::msg::Float32 angle_msg; 
-                if (abs(steering_0 - steering_1) < 10) { 
-                    angle_msg.data = steering_0; 
-                    last_steering_angle = steering_0; 
-                    update_odom(); 
-                } else { 
-                    angle_msg.data = 1111.0;  // error identifier (impossible value) 
-                } 
-                this->steering_angle_pub_->publish(angle_msg); 
-            } 
-            // BMU 
-            else if (msg.id == BMU_TransmitVoltage_ID) { 
-                uint8_t cmu_id; 
-                uint8_t packet_id; 
-                uint16_t voltages[3]; 
-                Parse_BMU_TransmitVoltage((uint8_t *)&msg.data[0], &cmu_id, &packet_id, voltages); 
-                for (int i = 0; i < 3 && (packet_id * 3 + i) < NUM_VOLTAGES; i++) { 
-                    this->bmu_status.brick_data[cmu_id].voltages[packet_id * 3 + i] = voltages[i]; 
-                } 
-                this->bmu_status_pub_->publish(this->bmu_status); 
- 
-            } else if (msg.id == BMU_TransmitTemperature_ID) { 
-                uint8_t cmu_id; 
-                uint8_t packet_id; 
-                uint8_t temps[6]; 
-                Parse_BMU_TransmitTemperatures((uint8_t *)&msg.data[0], &cmu_id, &packet_id, temps); 
-                for (int i = 0; i < 6 && (packet_id * 6 + i) < NUM_TEMPERATURES; i++) { 
-                    bmu_status.brick_data[cmu_id].temperatures[packet_id * 6 + i] = temps[i]; 
-                } 
-                this->bmu_status_pub_->publish(this->bmu_status); 
-            } 
-        } 
-    } 
- 
-    // ROS can msgs 
-    void canmsg_callback(const driverless_msgs::msg::Can::SharedPtr msg) const { this->socketCAN->tx(msg.get()); } 
- 
-   public: 
-    CanBus() : Node("canbus_translator_node") { 
-        // socketCAN parameters 
-        std::string _interface = this->declare_parameter<std::string>("interface", "can0"); 
-        this->get_parameter("interface", _interface); 
- 
-        RCLCPP_INFO(this->get_logger(), "Creating Connection on %s...", _interface.c_str()); 
-        this->socketCAN = std::make_shared<SocketCAN>(); 
-        this->socketCAN->setup(_interface); 
-        RCLCPP_INFO(this->get_logger(), "done!"); 
- 
-        // retrieve can messages from queue 
-        this->timer_ = this->create_wall_timer(std::chrono::milliseconds(1), std::bind(&CanBus::canmsg_timer, this)); 
-        // subscribe to can messages from ROS system 
-        this->can_sub_ = this->create_subscription<driverless_msgs::msg::Can>( 
-            "/can/canbus_carbound", QOS_ALL, std::bind(&CanBus::canmsg_callback, this, _1)); 
-        // publish can messages to ROS system 
-        this->can_pub_ = this->create_publisher<driverless_msgs::msg::Can>("/can/canbus_rosbound", 10); 
- 
-        // ADD PUBS FOR CAN TOPICS HERE 
-        // Steering ang 
-        this->steering_angle_pub_ = this->create_publisher<std_msgs::msg::Float32>("/vehicle/steering_angle", 10); 
-        // Vehicle velocity 
-        this->velocity_pub_ = this->create_publisher<std_msgs::msg::Float32>("/vehicle/velocity", 10); 
-        // Odometry 
-        this->odom_pub_ = this->create_publisher<nav_msgs::msg::Odometry>("/vehicle/wheel_odom", 10); 
-        // BMU 
-        this->bmu_status_pub_ = this->create_publisher<driverless_msgs::msg::CarStatus>("/vehicle/bmu_status", 10); 
-        this->bmu_status.brick_data = std::vector<driverless_msgs::msg::BrickData>(NUM_CMUS); 
-        for (int i = 0; i < NUM_CMUS; i++) { 
-            this->bmu_status.brick_data[i].id = i + 1; 
-            this->bmu_status.brick_data[i].voltages = std::vector<uint16_t>(NUM_VOLTAGES); 
-            this->bmu_status.brick_data[i].temperatures = std::vector<uint8_t>(NUM_TEMPERATURES); 
-        } 
- 
-        RCLCPP_INFO(this->get_logger(), "---CANBus Translator Node Initialised---"); 
-    } 
- 
-    ~CanBus() { this->socketCAN->~SocketCAN(); } 
-}; 
- 
-int main(int argc, char *argv[]) { 
-    rclcpp::init(argc, argv); 
-    rclcpp::spin(std::make_shared<CanBus>()); 
-    rclcpp::shutdown(); 
-    return 0; 
-} 
+#include <algorithm>
+#include <bitset>
+#include <iostream>
+
+#include "CAN_BMU.h"
+#include "CAN_DVL.h"
+#include "CAN_RES.h"
+#include "CAN_SW.h"
+#include "CAN_VCU.h"
+#include "CAN_VESC.h"
+#include "QUTMS_can.h"
+#include "SocketCAN.hpp"
+#include "driverless_common/common.hpp"
+#include "driverless_msgs/msg/can.hpp"
+#include "driverless_msgs/msg/car_status.hpp"
+#include "driverless_msgs/msg/res.hpp"
+#include "driverless_msgs/msg/wss_velocity.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/u_int8.hpp"
+
+using std::placeholders::_1;
+
+const int NUM_CMUS = 8;
+const int NUM_VOLTAGES = 14;
+const int NUM_TEMPERATURES = 16;
+const float WHEEL_DIAMETER = 0.4064;
+const float AXLE_WIDTH = 1.4;
+
+void copy_data(const std::vector<uint8_t> &vec, uint8_t *dest, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        dest[i] = vec[i];
+    }
+}
+
+// create array of CAN IDs we care about
+std::vector<uint32_t> can_ids = {
+    0x5F0,                  // C5_E stepper ID
+    (0x700 + RES_NODE_ID),  // boot up message
+    RES_Heartbeat_ID,
+};
+
+class CanBus : public rclcpp::Node {
+   private:
+    // can connection queue retrieval timer
+    rclcpp::TimerBase::SharedPtr timer_;
+
+    // subscriber
+    rclcpp::Subscription<driverless_msgs::msg::Can>::SharedPtr can_sub_;
+
+    // publishers
+    rclcpp::Publisher<driverless_msgs::msg::Can>::SharedPtr can_pub_;
+    // ADD PUBS FOR CAN TOPICS HERE
+    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr steering_angle_pub_;
+    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr velocity_pub_;
+    rclcpp::Publisher<driverless_msgs::msg::CarStatus>::SharedPtr bmu_status_pub_;
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+
+    // can connection
+    std::shared_ptr<SocketCAN> socketCAN;
+
+    // class variables for sensor data
+    float wheel_speeds[4];
+    driverless_msgs::msg::CarStatus bmu_status;
+    nav_msgs::msg::Odometry odom_msg;
+    float last_velocity;
+    float last_steering_angle;
+
+    void update_odom() {
+        // use last velocity and steering angle to update odom
+        odom_msg.header.stamp = this->now();
+        odom_msg.twist.twist.linear.x = last_velocity;
+        odom_msg.twist.twist.linear.y = 0.0;
+        odom_msg.twist.twist.angular.z = last_velocity * tan(last_steering_angle) / AXLE_WIDTH;
+        odom_pub_->publish(odom_msg);
+    }
+
+    void canmsg_timer() {
+        auto res = this->socketCAN->rx();
+
+        for (auto &msg : *res) {
+            uint32_t qutms_masked_id = msg.id & ~0xF;
+            // only publish can messages with IDs we care about to not flood memory
+            if (std::find(can_ids.begin(), can_ids.end(), msg.id) != can_ids.end()) {
+                this->can_pub_->publish(msg);
+            } else if (qutms_masked_id == VCU_Heartbeat_ID || qutms_masked_id == SW_Heartbeat_ID) {
+                this->can_pub_->publish(msg);
+            }
+
+            // CAN TRANSLATION OPTIONS
+            // Wheel speed velocity
+            uint32_t vesc_masked_id = (msg.id & ~0xFF) >> 8;
+            uint8_t vesc_id = msg.id & 0xFF;
+            if (vesc_id < 4) {
+                if (vesc_masked_id == VESC_CAN_PACKET_STATUS) {
+                    uint8_t data[8];
+                    copy_data(msg.data, data, 8);
+                    // extract and publish RPM
+                    int32_t rpm;
+                    float current;
+                    float duty;
+                    Parse_VESC_CANPacketStatus(data, &rpm, &current, &duty);
+
+                    wheel_speeds[vesc_id] = (rpm / (21.0 * 4.50)) * M_PI * WHEEL_DIAMETER / 60;
+                    float av_velocity = 0;
+                    for (int i = 0; i < 4; i++) {
+                        av_velocity += this->wheel_speeds[i];
+                    }
+                    av_velocity = av_velocity / 4;
+
+                    // publish velocity
+                    std_msgs::msg::Float32 vel_msg;
+                    vel_msg.data = av_velocity;
+                    last_velocity = av_velocity;
+                    this->velocity_pub_->publish(vel_msg);
+
+                    // update odom msg with new velocity
+                    update_odom();
+                }
+            }
+            // Steering Angle
+            else if (qutms_masked_id == VCU_TransmitSteering_ID) {
+                // data vector to uint8_t array
+                uint8_t data[8];
+                copy_data(msg.data, data, 8);
+
+                int16_t steering_0_raw;
+                int16_t steering_1_raw;
+                uint16_t adc_0;
+                uint16_t adc_1;
+
+                Parse_VCU_TransmitSteering(data, &steering_0_raw, &steering_1_raw, &adc_0, &adc_1);
+                // Log steering angle
+                RCLCPP_DEBUG(this->get_logger(), "Steering Angle 0: %i  Steering Angle 1: %i ADC 0: %i ADC 1: %i",
+                             steering_0_raw, steering_1_raw, adc_0, adc_1);
+                double steering_0 = steering_0_raw / 10.0;
+                double steering_1 = steering_1_raw / 10.0;
+
+                std_msgs::msg::Float32 angle_msg;
+                if (abs(steering_0 - steering_1) < 10) {
+                    angle_msg.data = steering_0;
+                    last_steering_angle = steering_0;
+                    update_odom();
+                } else {
+                    angle_msg.data = 1111.0;  // error identifier (impossible value)
+                }
+                this->steering_angle_pub_->publish(angle_msg);
+            }
+            // BMU
+            else if (msg.id == BMU_TransmitVoltage_ID) {
+                uint8_t cmu_id;
+                uint8_t packet_id;
+                uint16_t voltages[3];
+                Parse_BMU_TransmitVoltage((uint8_t *)&msg.data[0], &cmu_id, &packet_id, voltages);
+                for (int i = 0; i < 3 && (packet_id * 3 + i) < NUM_VOLTAGES; i++) {
+                    this->bmu_status.brick_data[cmu_id].voltages[packet_id * 3 + i] = voltages[i];
+                }
+                this->bmu_status_pub_->publish(this->bmu_status);
+
+            } else if (msg.id == BMU_TransmitTemperature_ID) {
+                uint8_t cmu_id;
+                uint8_t packet_id;
+                uint8_t temps[6];
+                Parse_BMU_TransmitTemperatures((uint8_t *)&msg.data[0], &cmu_id, &packet_id, temps);
+                for (int i = 0; i < 6 && (packet_id * 6 + i) < NUM_TEMPERATURES; i++) {
+                    bmu_status.brick_data[cmu_id].temperatures[packet_id * 6 + i] = temps[i];
+                }
+                this->bmu_status_pub_->publish(this->bmu_status);
+            }
+        }
+    }
+
+    // ROS can msgs
+    void canmsg_callback(const driverless_msgs::msg::Can::SharedPtr msg) const { this->socketCAN->tx(msg.get()); }
+
+   public:
+    CanBus() : Node("canbus_translator_node") {
+        // socketCAN parameters
+        std::string _interface = this->declare_parameter<std::string>("interface", "can0");
+        this->get_parameter("interface", _interface);
+
+        RCLCPP_INFO(this->get_logger(), "Creating Connection on %s...", _interface.c_str());
+        this->socketCAN = std::make_shared<SocketCAN>();
+        this->socketCAN->setup(_interface);
+        RCLCPP_INFO(this->get_logger(), "done!");
+
+        // retrieve can messages from queue
+        this->timer_ = this->create_wall_timer(std::chrono::milliseconds(1), std::bind(&CanBus::canmsg_timer, this));
+        // subscribe to can messages from ROS system
+        this->can_sub_ = this->create_subscription<driverless_msgs::msg::Can>(
+            "/can/canbus_carbound", QOS_ALL, std::bind(&CanBus::canmsg_callback, this, _1));
+        // publish can messages to ROS system
+        this->can_pub_ = this->create_publisher<driverless_msgs::msg::Can>("/can/canbus_rosbound", 10);
+
+        // ADD PUBS FOR CAN TOPICS HERE
+        // Steering ang
+        this->steering_angle_pub_ = this->create_publisher<std_msgs::msg::Float32>("/vehicle/steering_angle", 10);
+        // Vehicle velocity
+        this->velocity_pub_ = this->create_publisher<std_msgs::msg::Float32>("/vehicle/velocity", 10);
+        // Odometry
+        this->odom_pub_ = this->create_publisher<nav_msgs::msg::Odometry>("/vehicle/wheel_odom", 10);
+        // BMU
+        this->bmu_status_pub_ = this->create_publisher<driverless_msgs::msg::CarStatus>("/vehicle/bmu_status", 10);
+        this->bmu_status.brick_data = std::vector<driverless_msgs::msg::BrickData>(NUM_CMUS);
+        for (int i = 0; i < NUM_CMUS; i++) {
+            this->bmu_status.brick_data[i].id = i + 1;
+            this->bmu_status.brick_data[i].voltages = std::vector<uint16_t>(NUM_VOLTAGES);
+            this->bmu_status.brick_data[i].temperatures = std::vector<uint8_t>(NUM_TEMPERATURES);
+        }
+
+        RCLCPP_INFO(this->get_logger(), "---CANBus Translator Node Initialised---");
+    }
+
+    ~CanBus() { this->socketCAN->~SocketCAN(); }
+};
+
+int main(int argc, char *argv[]) {
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<CanBus>());
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/hardware/canbus/src/node_canbus_translator_socket.cpp
+++ b/src/hardware/canbus/src/node_canbus_translator_socket.cpp
@@ -1,0 +1,224 @@
+#include <algorithm> 
+#include <bitset> 
+#include <iostream> 
+ 
+#include "CAN_BMU.h" 
+#include "CAN_DVL.h" 
+#include "CAN_RES.h" 
+#include "CAN_SW.h" 
+#include "CAN_VCU.h" 
+#include "CAN_VESC.h" 
+#include "QUTMS_can.h" 
+#include "SocketCAN.hpp" 
+#include "driverless_common/common.hpp" 
+#include "driverless_msgs/msg/can.hpp" 
+#include "driverless_msgs/msg/car_status.hpp" 
+#include "driverless_msgs/msg/res.hpp" 
+#include "driverless_msgs/msg/wss_velocity.hpp" 
+#include "nav_msgs/msg/odometry.hpp" 
+#include "rclcpp/rclcpp.hpp" 
+#include "std_msgs/msg/bool.hpp" 
+#include "std_msgs/msg/float32.hpp" 
+#include "std_msgs/msg/u_int8.hpp" 
+ 
+using std::placeholders::_1; 
+ 
+const int NUM_CMUS = 8; 
+const int NUM_VOLTAGES = 14; 
+const int NUM_TEMPERATURES = 16; 
+const float WHEEL_DIAMETER = 0.4064; 
+const float AXLE_WIDTH = 1.4; 
+ 
+void copy_data(const std::vector<uint8_t> &vec, uint8_t *dest, size_t n) { 
+    for (size_t i = 0; i < n; i++) { 
+        dest[i] = vec[i]; 
+    } 
+} 
+ 
+// create array of CAN IDs we care about 
+std::vector<uint32_t> can_ids = { 
+    0x5F0,                  // C5_E stepper ID 
+    (0x700 + RES_NODE_ID),  // boot up message 
+    RES_Heartbeat_ID, 
+}; 
+ 
+class CanBus : public rclcpp::Node { 
+   private: 
+    // can connection queue retrieval timer 
+    rclcpp::TimerBase::SharedPtr timer_; 
+ 
+    // subscriber 
+    rclcpp::Subscription<driverless_msgs::msg::Can>::SharedPtr can_sub_; 
+ 
+    // publishers 
+    rclcpp::Publisher<driverless_msgs::msg::Can>::SharedPtr can_pub_; 
+    // ADD PUBS FOR CAN TOPICS HERE 
+    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr steering_angle_pub_; 
+    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr velocity_pub_; 
+    rclcpp::Publisher<driverless_msgs::msg::CarStatus>::SharedPtr bmu_status_pub_; 
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_; 
+ 
+    // can connection 
+    std::shared_ptr<SocketCAN> socketCAN; 
+ 
+    // class variables for sensor data 
+    float wheel_speeds[4]; 
+    driverless_msgs::msg::CarStatus bmu_status; 
+    nav_msgs::msg::Odometry odom_msg; 
+    float last_velocity; 
+    float last_steering_angle; 
+ 
+    void update_odom() { 
+        // use last velocity and steering angle to update odom 
+        odom_msg.header.stamp = this->now(); 
+        odom_msg.twist.twist.linear.x = last_velocity; 
+        odom_msg.twist.twist.linear.y = 0.0; 
+        odom_msg.twist.twist.angular.z = last_velocity * tan(last_steering_angle) / AXLE_WIDTH; 
+        odom_pub_->publish(odom_msg); 
+    } 
+ 
+    void canmsg_timer() { 
+        auto res = this->socketCAN->rx(); 
+ 
+        for (auto &msg : *res) { 
+            uint32_t qutms_masked_id = msg.id & ~0xF; 
+            // only publish can messages with IDs we care about to not flood memory 
+            if (std::find(can_ids.begin(), can_ids.end(), msg.id) != can_ids.end()) { 
+                this->can_pub_->publish(msg); 
+            } else if (qutms_masked_id == VCU_Heartbeat_ID || qutms_masked_id == SW_Heartbeat_ID) { 
+                this->can_pub_->publish(msg); 
+            } 
+ 
+            // CAN TRANSLATION OPTIONS 
+            // Wheel speed velocity 
+            uint32_t vesc_masked_id = (msg.id & ~0xFF) >> 8; 
+            uint8_t vesc_id = msg.id & 0xFF; 
+            if (vesc_id < 4) { 
+                if (vesc_masked_id == VESC_CAN_PACKET_STATUS) { 
+                    uint8_t data[8]; 
+                    copy_data(msg.data, data, 8); 
+                    // extract and publish RPM 
+                    int32_t rpm; 
+                    float current; 
+                    float duty; 
+                    Parse_VESC_CANPacketStatus(data, &rpm, &current, &duty); 
+ 
+                    wheel_speeds[vesc_id] = (rpm / (21.0 * 4.50)) * M_PI * WHEEL_DIAMETER / 60; 
+                    float av_velocity = 0; 
+                    for (int i = 0; i < 4; i++) { 
+                        av_velocity += this->wheel_speeds[i]; 
+                    } 
+                    av_velocity = av_velocity / 4; 
+ 
+                    // publish velocity 
+                    std_msgs::msg::Float32 vel_msg; 
+                    vel_msg.data = av_velocity; 
+                    last_velocity = av_velocity; 
+                    this->velocity_pub_->publish(vel_msg); 
+ 
+                    // update odom msg with new velocity 
+                    update_odom(); 
+                } 
+            } 
+            // Steering Angle 
+            else if (qutms_masked_id == VCU_TransmitSteering_ID) { 
+                // data vector to uint8_t array 
+                uint8_t data[8]; 
+                copy_data(msg.data, data, 8); 
+ 
+                int16_t steering_0_raw; 
+                int16_t steering_1_raw; 
+                uint16_t adc_0; 
+                uint16_t adc_1; 
+ 
+                Parse_VCU_TransmitSteering(data, &steering_0_raw, &steering_1_raw, &adc_0, &adc_1); 
+                // Log steering angle 
+                RCLCPP_DEBUG(this->get_logger(), "Steering Angle 0: %i  Steering Angle 1: %i ADC 0: %i ADC 1: %i", 
+                             steering_0_raw, steering_1_raw, adc_0, adc_1); 
+                double steering_0 = steering_0_raw / 10.0; 
+                double steering_1 = steering_1_raw / 10.0; 
+ 
+                std_msgs::msg::Float32 angle_msg; 
+                if (abs(steering_0 - steering_1) < 10) { 
+                    angle_msg.data = steering_0; 
+                    last_steering_angle = steering_0; 
+                    update_odom(); 
+                } else { 
+                    angle_msg.data = 1111.0;  // error identifier (impossible value) 
+                } 
+                this->steering_angle_pub_->publish(angle_msg); 
+            } 
+            // BMU 
+            else if (msg.id == BMU_TransmitVoltage_ID) { 
+                uint8_t cmu_id; 
+                uint8_t packet_id; 
+                uint16_t voltages[3]; 
+                Parse_BMU_TransmitVoltage((uint8_t *)&msg.data[0], &cmu_id, &packet_id, voltages); 
+                for (int i = 0; i < 3 && (packet_id * 3 + i) < NUM_VOLTAGES; i++) { 
+                    this->bmu_status.brick_data[cmu_id].voltages[packet_id * 3 + i] = voltages[i]; 
+                } 
+                this->bmu_status_pub_->publish(this->bmu_status); 
+ 
+            } else if (msg.id == BMU_TransmitTemperature_ID) { 
+                uint8_t cmu_id; 
+                uint8_t packet_id; 
+                uint8_t temps[6]; 
+                Parse_BMU_TransmitTemperatures((uint8_t *)&msg.data[0], &cmu_id, &packet_id, temps); 
+                for (int i = 0; i < 6 && (packet_id * 6 + i) < NUM_TEMPERATURES; i++) { 
+                    bmu_status.brick_data[cmu_id].temperatures[packet_id * 6 + i] = temps[i]; 
+                } 
+                this->bmu_status_pub_->publish(this->bmu_status); 
+            } 
+        } 
+    } 
+ 
+    // ROS can msgs 
+    void canmsg_callback(const driverless_msgs::msg::Can::SharedPtr msg) const { this->socketCAN->tx(msg.get()); } 
+ 
+   public: 
+    CanBus() : Node("canbus_translator_node") { 
+        // socketCAN parameters 
+        std::string _interface = this->declare_parameter<std::string>("interface", "can0"); 
+        this->get_parameter("interface", _interface); 
+ 
+        RCLCPP_INFO(this->get_logger(), "Creating Connection on %s...", _interface.c_str()); 
+        this->socketCAN = std::make_shared<SocketCAN>(); 
+        this->socketCAN->setup(_interface); 
+        RCLCPP_INFO(this->get_logger(), "done!"); 
+ 
+        // retrieve can messages from queue 
+        this->timer_ = this->create_wall_timer(std::chrono::milliseconds(1), std::bind(&CanBus::canmsg_timer, this)); 
+        // subscribe to can messages from ROS system 
+        this->can_sub_ = this->create_subscription<driverless_msgs::msg::Can>( 
+            "/can/canbus_carbound", QOS_ALL, std::bind(&CanBus::canmsg_callback, this, _1)); 
+        // publish can messages to ROS system 
+        this->can_pub_ = this->create_publisher<driverless_msgs::msg::Can>("/can/canbus_rosbound", 10); 
+ 
+        // ADD PUBS FOR CAN TOPICS HERE 
+        // Steering ang 
+        this->steering_angle_pub_ = this->create_publisher<std_msgs::msg::Float32>("/vehicle/steering_angle", 10); 
+        // Vehicle velocity 
+        this->velocity_pub_ = this->create_publisher<std_msgs::msg::Float32>("/vehicle/velocity", 10); 
+        // Odometry 
+        this->odom_pub_ = this->create_publisher<nav_msgs::msg::Odometry>("/vehicle/wheel_odom", 10); 
+        // BMU 
+        this->bmu_status_pub_ = this->create_publisher<driverless_msgs::msg::CarStatus>("/vehicle/bmu_status", 10); 
+        this->bmu_status.brick_data = std::vector<driverless_msgs::msg::BrickData>(NUM_CMUS); 
+        for (int i = 0; i < NUM_CMUS; i++) { 
+            this->bmu_status.brick_data[i].id = i + 1; 
+            this->bmu_status.brick_data[i].voltages = std::vector<uint16_t>(NUM_VOLTAGES); 
+            this->bmu_status.brick_data[i].temperatures = std::vector<uint8_t>(NUM_TEMPERATURES); 
+        } 
+ 
+        RCLCPP_INFO(this->get_logger(), "---CANBus Translator Node Initialised---"); 
+    } 
+ 
+    ~CanBus() { this->socketCAN->~SocketCAN(); } 
+}; 
+ 
+int main(int argc, char *argv[]) { 
+    rclcpp::init(argc, argv); 
+    rclcpp::spin(std::make_shared<CanBus>()); 
+    rclcpp::shutdown(); 
+    return 0; 
+} 

--- a/src/machines/roscube_machine/launch/machine.launch.py
+++ b/src/machines/roscube_machine/launch/machine.launch.py
@@ -14,7 +14,7 @@ def generate_launch_description():
             ),
             Node(
                 package="canbus",
-                executable="canbus_translator_node",
+                executable="canbus_translator_socket_node",
                 parameters=[
                     get_package_share_path("canbus") / "config" / "canbus.yaml",
                 ],


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide evidence of tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimisation

## [required] Description

Adds socketcan implementation for CAN to ROS translation. Leverages our CAN PCIe module for direct connection from GPIO rather than an eth adapter for faster :tm: msg handling.

### [optional] Usability concerns or breaking changes?

Nothing breaking, but things will break without it :)
