### PR TITLE
Nav launching

### DIFF
--- a/src/common/driverless_msgs/msg/State.msg
+++ b/src/common/driverless_msgs/msg/State.msg
@@ -22,3 +22,5 @@ uint8 EBS_TEST=3
 uint8 TRACKDRIVE=4
 
 uint8 lap_count
+
+bool navigation_ready

--- a/src/control/controllers/controllers/node_reactive_control.py
+++ b/src/control/controllers/controllers/node_reactive_control.py
@@ -40,14 +40,14 @@ class ReactiveController(Node):
         self.driving = False
         self.discovering = False
 
-        self.declare_parameter("ebs_control", False)
+        self.declare_parameter("ebs_control", True)
         self.ebs_test = self.get_parameter("ebs_control").value
 
         self.get_logger().info("EBS Control: " + str(self.ebs_test))
 
         if self.ebs_test:
-            self.Kp_ang = 2.0
-            self.target_vel = 12.0  # m/s
+            self.Kp_ang = 0.2
+            self.target_vel = 5.0  # m/s
         else:
             self.Kp_ang = 1.8
             self.target_vel = 2.0  # m/s
@@ -65,7 +65,7 @@ class ReactiveController(Node):
         return cones[min(index + self.target_offset, len(cones) - 1)]
 
     def state_callback(self, msg: State):
-        if msg.state == State.DRIVING and not self.driving:
+        if msg.state == State.DRIVING and not self.driving and msg.navigation_ready:
             # delay starting driving for 2 seconds to allow for mapping to start
             time.sleep(2)
             self.driving = True

--- a/src/hardware/steering_actuator/config/steering.yaml
+++ b/src/hardware/steering_actuator/config/steering.yaml
@@ -11,7 +11,10 @@ steering_actuator_node:
     velocity_centering: 20
     acceleration: 1000
     acceleration_centering: 50
-    centre_range: 0.5
+    centre_range: 2.0
+    centre_angle: -8.0
+    settling_iter: 50
+    max_position: 7500
     Kp: 10.0
     Ki: 0.0
     Kd: 0.0

--- a/src/hardware/steering_actuator/src/node_steering_actuator_test.cpp
+++ b/src/hardware/steering_actuator/src/node_steering_actuator_test.cpp
@@ -9,6 +9,7 @@
 #include "driverless_msgs/msg/can.hpp"  // ROS Messages
 #include "driverless_msgs/msg/state.hpp"
 #include "rclcpp/rclcpp.hpp"  // C++ Required Libraries
+#include "std_msgs/msg/bool.hpp"
 #include "std_msgs/msg/float32.hpp"
 #include "std_msgs/msg/int32.hpp"
 #include "steering_actuator/steering_common.hpp"
@@ -19,52 +20,53 @@ using std::placeholders::_1;
 class SteeringActuator : public rclcpp::Node, public CanInterface {
    private:
     // Creates
-    rclcpp::TimerBase::SharedPtr steering_update_timer;
-    rclcpp::TimerBase::SharedPtr state_request_timer;
+    rclcpp::TimerBase::SharedPtr steering_update_timer_;
+    rclcpp::TimerBase::SharedPtr state_request_timer_;
 
     // Creates publishers and subscribers
-    rclcpp::Publisher<driverless_msgs::msg::Can>::SharedPtr can_pub;
-    rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr encoder_pub;
-    rclcpp::Subscription<driverless_msgs::msg::State>::SharedPtr state_sub;
-    rclcpp::Subscription<ackermann_msgs::msg::AckermannDriveStamped>::SharedPtr ackermann_sub;
-    rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr steer_ang_sub;
+    rclcpp::Publisher<driverless_msgs::msg::Can>::SharedPtr can_pub_;
+    rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr encoder_pub_;
+    rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr steering_ready_pub_;
+    rclcpp::Subscription<driverless_msgs::msg::State>::SharedPtr state_sub_;
+    rclcpp::Subscription<ackermann_msgs::msg::AckermannDriveStamped>::SharedPtr ackermann_sub_;
+    rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr steer_ang_sub_;
     rclcpp::Subscription<driverless_msgs::msg::Can>::SharedPtr canopen_sub_;
 
     rclcpp::CallbackGroup::SharedPtr callback_group_subscriber1_;
     rclcpp::CallbackGroup::SharedPtr callback_group_subscriber2_;
 
     // params
-    double Kp, Ki, Kd, centre_range;
+    double Kp_, Ki_, Kd_, centre_range_, centre_angle_;
+    int settling_iter_, max_position_;
 
-    bool shutdown_requested = false;
-    driverless_msgs::msg::State state;
-    c5e_state desired_state = states[RTSO];
-    c5e_state current_state = states[NRTSO];
-    uint16_t control_method = MODE_RELATIVE;
-    bool motor_enabled = true;
-    bool centred = false;
-    int32_t offset = 0;
-    int settled_count = 0;
-    bool initial_enc_saved = false;
-    int32_t initial_enc = 0;
-    bool steering_ang_received = false;
-    double current_steering_angle = 0;
-    double center_angle = -2.0;           // angle sensor has a -2 deg offset
-    int32_t current_enc_revolutions = 0;  // Current Encoder Revolutions (Stepper encoder)
-    uint32_t current_velocity;
-    uint32_t current_acceleration;
+    bool shutdown_requested_ = false;
+    driverless_msgs::msg::State state_;
+    c5e_state desired_state_ = states[RTSO];
+    c5e_state current_state_ = states[NRTSO];
+    uint16_t control_method_ = MODE_RELATIVE;
+    bool motor_enabled_ = false;
+    bool centred_ = false;
+    int32_t offset_ = 0;
+    int settled_count_ = 0;
+    bool initial_enc_saved_ = false;
+    int32_t initial_enc_ = 0;
+    bool steering_ang_received_ = false;
+    double current_steering_angle_ = 0;
+    int32_t current_enc_revolutions_ = 0;  // Current Encoder Revolutions (Stepper encoder)
+    uint32_t current_velocity_;
+    uint32_t current_acceleration_;
 
     // time to reset node if no state received
     std::chrono::time_point<std::chrono::system_clock> last_state_time = std::chrono::system_clock::now();
 
     void configure_c5e() {
-        this->send_steering_data(PROFILE_VELOCITY, (uint8_t *)&this->current_velocity, 4);
-        this->send_steering_data(PROFILE_ACCELERATION, (uint8_t *)&this->current_acceleration, 4);
-        this->send_steering_data(PROFILE_DECELERATION, (uint8_t *)&this->current_acceleration, 4);
-        this->send_steering_data(QUICK_STOP_DECELERATION, (uint8_t *)&this->current_acceleration, 4);
-        this->send_steering_data(MAX_ACCELERATION, (uint8_t *)&this->current_acceleration, 4);
-        this->send_steering_data(MAX_DECELERATION, (uint8_t *)&this->current_acceleration, 4);
-        // this->send_steering_data(HOME_OFFSET, (uint8_t *)&this->offset, 4);
+        this->send_steering_data(PROFILE_VELOCITY, (uint8_t *)&current_velocity_, 4);
+        this->send_steering_data(PROFILE_ACCELERATION, (uint8_t *)&current_acceleration_, 4);
+        this->send_steering_data(PROFILE_DECELERATION, (uint8_t *)&current_acceleration_, 4);
+        this->send_steering_data(QUICK_STOP_DECELERATION, (uint8_t *)&current_acceleration_, 4);
+        this->send_steering_data(MAX_ACCELERATION, (uint8_t *)&current_acceleration_, 4);
+        this->send_steering_data(MAX_DECELERATION, (uint8_t *)&current_acceleration_, 4);
+        // this->send_steering_data(HOME_OFFSET, (uint8_t *)&offset_, 4);
 
         RCLCPP_INFO(this->get_logger(), "Configured C5E");
     }
@@ -72,43 +74,50 @@ class SteeringActuator : public rclcpp::Node, public CanInterface {
     void c5e_state_request_callback() {
         this->read_steering_data(STATUS_WORD);
         // RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 250, "Requesting state");
+        std_msgs::msg::Bool msg;
+        msg.data = centred_;
+        steering_ready_pub_->publish(msg);
     }
 
     // Check State to enable or disable motor
     void as_state_callback(const driverless_msgs::msg::State msg) {
-        this->state = msg;
+        state_ = msg;
         if (msg.state == driverless_msgs::msg::State::DRIVING ||
-            msg.state == driverless_msgs::msg::State::ACTIVATE_EBS ||
-            msg.state == driverless_msgs::msg::State::EMERGENCY) {
+            msg.state == driverless_msgs::msg::State::ACTIVATE_EBS) {
             // Enable motor
-            this->motor_enabled = true;
+            motor_enabled_ = true;
         } else {
-            this->motor_enabled = false;
+            // Disable motor
+            motor_enabled_ = false;
+            centred_ = false;
+            settled_count_ = 0;
+            initial_enc_saved_ = false;
+            steering_ang_received_ = false;
         }
     }
 
     // Get steering angle reading
     void steering_angle_callback(const std_msgs::msg::Float32 msg) {
-        this->current_steering_angle = msg.data;
-        if (!this->steering_ang_received) this->steering_ang_received = true;
+        current_steering_angle_ = msg.data;
+        if (!steering_ang_received_) steering_ang_received_ = true;
         RCLCPP_INFO_ONCE(this->get_logger(), "Steering angle received");
         RCLCPP_DEBUG(this->get_logger(), "Current angle: %f", msg.data);
     }
 
     // Get desired steering angle to update steering
     void driving_command_callback(const ackermann_msgs::msg::AckermannDriveStamped msg) {
-        if (!this->motor_enabled || !this->centred) return;
+        if (!motor_enabled_ || !centred_) return;
 
         double requested_steering_angle = msg.drive.steering_angle;
         // RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 500, "Requested angle: %f",
         // msg.drive.steering_angle); turning left eqn: -83.95x - 398.92 turning right eqn: -96.19x - 83.79
         int32_t target;
-        if (requested_steering_angle > this->center_angle) {
-            target = int32_t(-86.45 * requested_steering_angle - 398.92) - this->offset;
+        if (requested_steering_angle > centre_angle_) {
+            target = int32_t(-86.45 * requested_steering_angle - 398.92) - offset_;
         } else {
-            target = int32_t(-94.58 * requested_steering_angle - 83.79) - this->offset;
+            target = int32_t(-94.58 * requested_steering_angle - 83.79) - offset_;
         }
-        target = std::max(std::min(target, 7500 - this->offset), -7500 - this->offset);
+        target = std::max(std::min(target, max_position_ - offset_), -max_position_ - offset_);
         RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 250, "Target: %f = %d", requested_steering_angle,
                              target);
         this->target_position(target);
@@ -134,73 +143,67 @@ class SteeringActuator : public rclcpp::Node, public CanInterface {
 
             // message received for position revolution
             int32_t val = (int32_t)data;
-            this->current_enc_revolutions = val;
-            if (!this->initial_enc_saved) {
+            current_enc_revolutions_ = val;
+            if (!initial_enc_saved_) {
                 RCLCPP_INFO_ONCE(this->get_logger(), "Position received");
-                this->initial_enc = val;
-                this->initial_enc_saved = true;
+                // initial_enc_ = val;
+                initial_enc_saved_ = true;
             }
-            // RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 500, "Encoder: %d", val);
 
             std_msgs::msg::Int32 enc_msg;
-            enc_msg.data = this->current_enc_revolutions;
-            this->encoder_pub->publish(enc_msg);
+            enc_msg.data = current_enc_revolutions_;
+            encoder_pub_->publish(enc_msg);
         } else if (msg.id == C5E_SRV_ID) {
             // objects returned from sdo read
             uint16_t object_id = (msg.data[2] & 0xFF) << 8 | (msg.data[1] & 0xFF);
 
             // if (msg.data[0] == 0x60 || msg.data[0] == 0x80) {
             if (msg.data[0] == 0x80) {
-                // acknowledgements of sdo write
-                // 0x60 -> success ack
-                // 0x80 -> error ack
+                // acknowledgements of sdo write: 0x60 -> success ack, 0x80 -> error ack
                 RCLCPP_INFO(this->get_logger(), "ACK object: %x, %x", object_id, msg.data[0]);
                 return;
             }
-            // RCLCPP_INFO(this->get_logger(), "Object: %x, %x", object_id, msg.data[0]);
 
             if (object_id == STATUS_WORD) {
                 uint16_t status_word = (msg.data[5] << 8 | msg.data[4]);
-                this->current_state = parse_state(status_word);
-                RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 100, "Status word: %s",
-                                     std::bitset<16>(status_word).to_string().c_str());
-                RCLCPP_DEBUG(this->get_logger(), "Current state: %s", this->current_state.name.c_str());
+                current_state_ = parse_state(status_word);
+                RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 100, "Status word: %s",
+                                      std::bitset<16>(status_word).to_string().c_str());
+                RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 100, "Current state: %s",
+                                      current_state_.name.c_str());
 
-                if (this->motor_enabled) {
-                    if (this->current_state == states[RTSO]) {
-                        this->desired_state = states[SO];
-                    } else if (this->current_state == states[SO]) {
-                        this->desired_state = states[OE];
+                if (motor_enabled_) {
+                    if (current_state_ == states[RTSO]) {
+                        desired_state_ = states[SO];
+                    } else if (current_state_ == states[SO]) {
+                        desired_state_ = states[OE];
                         // default params
                         this->configure_c5e();
-                    } else if (this->current_state == states[OE]) {
-                        // if (!this->centred && this->steering_ang_received) {
-                        //     this->pre_op_centering();
-                        // }
+                    } else if (current_state_ == states[OE]) {
                         // stay here -> no transition
                     } else {
-                        this->desired_state = states[RTSO];
+                        desired_state_ = states[RTSO];
                     }
                 } else {
                     // disabled transitions
-                    this->desired_state = states[RTSO];
+                    desired_state_ = states[RTSO];
                 }
 
-                if (shutdown_requested) {
-                    this->desired_state = states[RTSO];
-                    if (this->current_state == this->desired_state) {
+                if (shutdown_requested_) {
+                    desired_state_ = states[RTSO];
+                    if (current_state_ == desired_state_) {
                         rclcpp::shutdown();
                     }
                 }
 
                 // Print current and desired states
-                RCLCPP_DEBUG(this->get_logger(), "Desired state: %s", this->desired_state.name.c_str());
+                RCLCPP_DEBUG(this->get_logger(), "Desired state: %s", desired_state_.name.c_str());
 
                 // State transition stage via state map definitions
-                if (this->current_state != this->desired_state) {
-                    RCLCPP_INFO(this->get_logger(), "Current state: %s", this->current_state.name.c_str());
-                    RCLCPP_INFO(this->get_logger(), "Sending state: %s", this->desired_state.name.c_str());
-                    this->send_steering_data(CONTROL_WORD, (uint8_t *)&this->desired_state.control_word, 2);
+                if (current_state_ != desired_state_) {
+                    RCLCPP_INFO(this->get_logger(), "Current state: %s", current_state_.name.c_str());
+                    RCLCPP_INFO(this->get_logger(), "Sending state: %s", desired_state_.name.c_str());
+                    this->send_steering_data(CONTROL_WORD, (uint8_t *)&desired_state_.control_word, 2);
                 }
             }
         }
@@ -208,52 +211,51 @@ class SteeringActuator : public rclcpp::Node, public CanInterface {
 
     // Update Steering
     void pre_op_centering() {
-        if (!this->motor_enabled || !this->steering_ang_received || this->centred || this->current_state != states[OE])
+        if (!motor_enabled_ || !steering_ang_received_ || centred_ || current_state_ != states[OE])
             return;  // if multithread doesn't work
 
         RCLCPP_INFO_ONCE(this->get_logger(), "Centering");
         // center steering
         // splitting into threads means steering angle will be updated separately to this function
-        // while (this->settled_count < 200) {
-        if (this->settled_count < 200) {  // if multithread doesn't work
-            double error = this->current_steering_angle - this->center_angle;
+        if (settled_count_ < settling_iter_) {  // if multithread doesn't work
+            double error = current_steering_angle_ - centre_angle_;
             RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "Error: %f", error);
-            if (abs(error) < this->centre_range) {
+            if (abs(error) < centre_range_) {
                 // motor has settled enough
-                this->settled_count += 1;
+                settled_count_ += 1;
             } else {
                 // reset settled count to debounce initial overshoots
-                this->settled_count = 0;
+                settled_count_ = 0;
             }
             // left hand down is +, rhd is -
-            double target = this->Kp * error;  // P commands to send to plant
+            double target = Kp_ * error;  // P commands to send to plant
             this->target_position(target);
             return;  // if multithread doesn't work
         }
-        this->offset = this->initial_enc - this->current_enc_revolutions;
-        this->centred = true;
+        offset_ = initial_enc_ - current_enc_revolutions_;
+        centred_ = true;
         // save offset and configure c5e for different motion profile
-        this->current_velocity = this->get_parameter("velocity").as_int();
-        this->current_acceleration = this->get_parameter("acceleration").as_int();
-        this->control_method = MODE_ABSOLUTE;
-        RCLCPP_INFO_ONCE(this->get_logger(), "Centered, offset: %d", this->offset);
+        current_velocity_ = this->get_parameter("velocity").as_int();
+        current_acceleration_ = this->get_parameter("acceleration").as_int();
+        control_method_ = MODE_ABSOLUTE;
+        RCLCPP_INFO_ONCE(this->get_logger(), "Centered, offset: %d", offset_);
         this->configure_c5e();
         return;
     }
 
     void target_position(int32_t target) {
-        if (this->current_state != states[OE]) {
+        if (current_state_ != states[OE]) {
             RCLCPP_INFO_ONCE(this->get_logger(), "Not enabled");
             return;
         }
         RCLCPP_INFO_ONCE(this->get_logger(), "Enabled, Targeting");
 
-        this->send_steering_data(CONTROL_WORD, (uint8_t *)&this->control_method, 2);
+        this->send_steering_data(CONTROL_WORD, (uint8_t *)&control_method_, 2);
         // print bitset control word
         // RCLCPP_INFO(this->get_logger(), "Control word: %s",
-        // std::bitset<16>(this->control_method).to_string().c_str());
+        // std::bitset<16>(control_method_).to_string().c_str());
         this->send_steering_data(TARGET_POSITION, (uint8_t *)&target, 4);
-        uint16_t trigger_control_method = this->control_method | TRIGGER_MOTION;
+        uint16_t trigger_control_method = control_method_ | TRIGGER_MOTION;
         this->send_steering_data(CONTROL_WORD, (uint8_t *)&trigger_control_method, 2);
         // RCLCPP_INFO(this->get_logger(),"Trigger control word: %s",
         // std::bitset<16>(trigger_control_method).to_string().c_str());
@@ -263,14 +265,14 @@ class SteeringActuator : public rclcpp::Node, public CanInterface {
         uint32_t id;                                                                    // Packet id out
         uint8_t out[8];                                                                 // Data out
         sdo_write(C5E_NODE_ID, obj_index, 0x00, (uint8_t *)data, data_size, &id, out);  // Control Word
-        this->can_pub->publish(_d_2_f(id, 0, out, sizeof(out)));
+        can_pub_->publish(_d_2_f(id, 0, out, sizeof(out)));
     }
 
     void read_steering_data(uint16_t obj_index) {
         uint32_t id;                                       // Packet id out
         uint8_t out[8];                                    // Data out
         sdo_read(C5E_NODE_ID, obj_index, 0x00, &id, out);  // Control Word
-        this->can_pub->publish(_d_2_f(id, 0, out, sizeof(out)));
+        can_pub_->publish(_d_2_f(id, 0, out, sizeof(out)));
     }
 
    public:
@@ -280,64 +282,72 @@ class SteeringActuator : public rclcpp::Node, public CanInterface {
         this->declare_parameter<int>("velocity_centering", 100);
         this->declare_parameter<int>("acceleration", 2000);
         this->declare_parameter<int>("acceleration_centering", 100);
-        this->declare_parameter<float>("centre_range", 5);
+        this->declare_parameter<float>("centre_range", 5.0);
+        this->declare_parameter<float>("centre_angle", -2.0);
+        this->declare_parameter<int>("settling_iter", 20);
+        this->declare_parameter<int>("max_position", 7500);
         // PID controller parameters
         this->declare_parameter<double>("Kp", 1.0);
         this->declare_parameter<float>("Ki", 0.0);
         this->declare_parameter<float>("Kd", 0.0);
 
-        this->centre_range = this->get_parameter("centre_range").as_double();
-        this->Kp = this->get_parameter("Kp").as_double();
-        this->Ki = this->get_parameter("Ki").as_double();
-        this->Kd = this->get_parameter("Kd").as_double();
-        this->current_velocity = this->get_parameter("velocity").as_int();
-        this->current_acceleration = this->get_parameter("acceleration").as_int();
+        centre_range_ = this->get_parameter("centre_range").as_double();
+        centre_angle_ = this->get_parameter("centre_angle").as_double();
+        settling_iter_ = this->get_parameter("settling_iter").as_int();
+        max_position_ = this->get_parameter("max_position").as_int();
+        Kp_ = this->get_parameter("Kp").as_double();
+        Ki_ = this->get_parameter("Ki").as_double();
+        Kd_ = this->get_parameter("Kd").as_double();
+        current_velocity_ = this->get_parameter("velocity").as_int();
+        current_acceleration_ = this->get_parameter("acceleration").as_int();
 
         callback_group_subscriber1_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
         callback_group_subscriber2_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-
         auto sub1_opt = rclcpp::SubscriptionOptions();
         sub1_opt.callback_group = callback_group_subscriber1_;
         auto sub2_opt = rclcpp::SubscriptionOptions();
         sub2_opt.callback_group = callback_group_subscriber2_;
 
         // Create subscriber to topic "canbus_rosbound"
-        this->canopen_sub_ = this->create_subscription<driverless_msgs::msg::Can>(
+        canopen_sub_ = this->create_subscription<driverless_msgs::msg::Can>(
             "/can/canopen_rosbound", QOS_ALL, std::bind(&SteeringActuator::can_callback, this, _1), sub1_opt);
 
         // Create subscriber to topic "steering_angle"
-        this->steer_ang_sub = this->create_subscription<std_msgs::msg::Float32>(
+        steer_ang_sub_ = this->create_subscription<std_msgs::msg::Float32>(
             "/vehicle/steering_angle", QOS_ALL, std::bind(&SteeringActuator::steering_angle_callback, this, _1),
             sub2_opt);
 
         // Create subscriber to topic "driving_command"
-        this->ackermann_sub = this->create_subscription<ackermann_msgs::msg::AckermannDriveStamped>(
+        ackermann_sub_ = this->create_subscription<ackermann_msgs::msg::AckermannDriveStamped>(
             "/control/driving_command", QOS_ALL, std::bind(&SteeringActuator::driving_command_callback, this, _1),
             sub2_opt);
 
         // Create subscriber to topic AS status
-        // this->state_sub = this->create_subscription<driverless_msgs::msg::State>(
-        //     "/system/as_status", QOS_ALL, std::bind(&SteeringActuator::as_state_callback, this, _1));
+        state_sub_ = this->create_subscription<driverless_msgs::msg::State>(
+            "/system/as_status", QOS_ALL, std::bind(&SteeringActuator::as_state_callback, this, _1));
 
-        this->steering_update_timer = this->create_wall_timer(std::chrono::milliseconds(50),
-                                                              std::bind(&SteeringActuator::pre_op_centering, this));
+        steering_update_timer_ = this->create_wall_timer(std::chrono::milliseconds(50),
+                                                         std::bind(&SteeringActuator::pre_op_centering, this));
 
         // Create state request and config timers
-        this->state_request_timer = this->create_wall_timer(
-            std::chrono::milliseconds(200), std::bind(&SteeringActuator::c5e_state_request_callback, this),
-            callback_group_subscriber1_);
+        state_request_timer_ = this->create_wall_timer(std::chrono::milliseconds(200),
+                                                       std::bind(&SteeringActuator::c5e_state_request_callback, this),
+                                                       callback_group_subscriber1_);
 
         // Create publisher to topic "canbus_carbound"
-        this->can_pub = this->create_publisher<driverless_msgs::msg::Can>("/can/canbus_carbound", QOS_ALL);
+        can_pub_ = this->create_publisher<driverless_msgs::msg::Can>("/can/canbus_carbound", QOS_ALL);
 
         // Create publisher to topic "encoder_reading"
-        this->encoder_pub = this->create_publisher<std_msgs::msg::Int32>("/vehicle/encoder_reading", QOS_ALL);
+        encoder_pub_ = this->create_publisher<std_msgs::msg::Int32>("/vehicle/encoder_reading", QOS_ALL);
+
+        // Create publisher to topic "steering_state"
+        steering_ready_pub_ = this->create_publisher<std_msgs::msg::Bool>("/system/steering_ready", QOS_ALL);
 
         RCLCPP_INFO(this->get_logger(), "---Steering Actuator Node Initialised---");
     }
 
     // Shutdown system
-    void shutdown() { this->shutdown_requested = true; }
+    void shutdown() { shutdown_requested_ = true; }
 };
 
 // Prototype functions initialisations?

--- a/src/machines/roscube_machine/launch/machine.launch.py
+++ b/src/machines/roscube_machine/launch/machine.launch.py
@@ -10,7 +10,7 @@ def generate_launch_description():
         [
             Node(
                 package="mission_controller",
-                executable="mission_launcher",
+                executable="mission_launcher_node",
             ),
             Node(
                 package="canbus",
@@ -22,6 +22,9 @@ def generate_launch_description():
             Node(
                 package="vehicle_supervisor",
                 executable="vehicle_supervisor_slim_node",
+                parameters=[
+                    {"manual_override": False},
+                ],
             ),
             Node(
                 package="rosboard",
@@ -30,6 +33,20 @@ def generate_launch_description():
             Node(
                 package="driverless_common",
                 executable="display",
+            ),
+            Node(
+                package="steering_actuator",
+                executable="steering_actuator_test_node",
+                parameters=[
+                    get_package_share_path("steering_actuator") / "config" / "steering.yaml",
+                ],
+            ),
+            Node(
+                package="velocity_controller",
+                executable="velocity_controller_node",
+                parameters=[
+                    get_package_share_path("velocity_controller") / "config" / "velocity_controller.yaml",
+                ],
             ),
             Node(
                 package="lidar_pipeline",

--- a/src/operations/mission_controller/launch/ebs_test.launch.py
+++ b/src/operations/mission_controller/launch/ebs_test.launch.py
@@ -4,21 +4,4 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    return LaunchDescription(
-        [
-            Node(
-                package="steering_actuator",
-                executable="steering_actuator_test_node",
-                parameters=[
-                    get_package_share_path("steering_actuator") / "config" / "steering.yaml",
-                ],
-            ),
-            Node(
-                package="velocity_controller",
-                executable="velocity_controller_node",
-                parameters=[
-                    get_package_share_path("velocity_controller") / "config" / "velocity_controller.yaml",
-                ],
-            ),
-        ]
-    )
+    return LaunchDescription([Node(package="controllers", executable="point_fitting2")])

--- a/src/operations/mission_controller/launch/inspection.launch.py
+++ b/src/operations/mission_controller/launch/inspection.launch.py
@@ -7,19 +7,8 @@ def generate_launch_description():
     return LaunchDescription(
         [
             Node(
-                package="mission_controller",
-                executable="inspection_mission",
-            ),
-            Node(
                 package="controllers",
                 executable="sine",
-            ),
-            Node(
-                package="steering_actuator",
-                executable="steering_actuator_test_node",
-                parameters=[
-                    get_package_share_path("steering_actuator") / "config" / "steering.yaml",
-                ],
             ),
         ]
     )

--- a/src/operations/mission_controller/launch/trackdrive.launch.py
+++ b/src/operations/mission_controller/launch/trackdrive.launch.py
@@ -8,7 +8,6 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    nav_package_share = get_package_share_path("qutms_nav2")
     return LaunchDescription(
         [
             Node(

--- a/src/operations/mission_controller/mission_controller/node_inspection_handler.py
+++ b/src/operations/mission_controller/mission_controller/node_inspection_handler.py
@@ -1,32 +1,52 @@
+from subprocess import Popen
+import time
+
 import rclpy
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 
-from driverless_msgs.msg import Reset, Shutdown
+from driverless_msgs.msg import Shutdown, State
 
 from driverless_common.common import QOS_LATEST
 from driverless_common.shutdown_node import ShutdownNode
 
 
-class InspectionHandler(ShutdownNode):
-    started: bool = False
+class InspectionHandler(Node):
+    mission_started = False
+    start_time = 0.0
+    process = None
 
     def __init__(self):
         super().__init__("inspection_logic_node")
-        self.timer = self.create_timer(30, self.timer_callback)
-        self.reset_sub = self.create_subscription(Reset, "/system/reset", self.reset_callback, QOS_LATEST)
+        self.timer = self.create_timer(1.0, self.timer_callback)
+        self.reset_sub = self.create_subscription(State, "/system/as_status", self.state_callback, QOS_LATEST)
         self.shutdown_pub: Publisher = self.create_publisher(Shutdown, "/system/shutdown", 1)
 
         self.get_logger().info("---Inspection handler node initialised---")
 
-    def reset_callback(self, msg: Reset):
-        self.timer.reset()
-        self.started = True
+    def state_callback(self, msg: State):
+        # super().state_callback(msg)
+        if (
+            msg.state == State.DRIVING
+            and msg.mission == State.INSPECTION
+            and msg.navigation_ready
+            and not self.mission_started
+        ):
+            self.mission_started = True
+            self.start_time = time.time()
+            command = ["stdbuf", "-o", "L", "ros2", "launch", "mission_controller", "inspection.launch.py"]
+            self.get_logger().info(f"Command: {' '.join(command)}")
+            self.process = Popen(command)
+            self.get_logger().info("Trackdrive mission started")
 
     def timer_callback(self):
-        if self.started:
+        if self.mission_started and time.time() - self.start_time > 30:
             shutdown_msg = Shutdown(finished_engage_ebs=True)
             self.shutdown_pub.publish(shutdown_msg)
+            self.get_logger().info("Inspection mission finished")
+            self.get_logger().warn("Closing Inspection mission")
+            self.process.terminate()
+            self.destroy_node()
 
 
 def main(args=None):

--- a/src/operations/mission_controller/mission_controller/node_mission_launcher.py
+++ b/src/operations/mission_controller/mission_controller/node_mission_launcher.py
@@ -23,12 +23,25 @@ class MissionControl(Node):
     def callback(self, status: State):
         if status.mission != State.MISSION_NONE and status.state != State.EMERGENCY and not self.mission_launched:
             target_mission = INT_MISSION_TYPE[status.mission].value
-            launch_file = target_mission + ".launch.py"
-            command = ["stdbuf", "-o", "L", "ros2", "launch", "mission_controller", launch_file]
-            self.get_logger().info(f"Command: {' '.join(command)}")
-            self.process = Popen(command)
-            self.get_logger().info("Mission started: " + target_mission)
-            self.mission_launched = True
+            if target_mission == "ebs_test":
+                command = ["stdbuf", "-o", "L", "ros2", "launch", "mission_controller", "ebs_test.launch.py"]
+                self.get_logger().info(f"Command: {' '.join(command)}")
+                self.process = Popen(command)
+                self.get_logger().info("Mission started: " + target_mission)
+                self.mission_launched = True
+
+            else:
+                node = target_mission + "_handler_node"
+                command = ["stdbuf", "-o", "L", "ros2", "run", "mission_controller", node]
+                self.get_logger().info(f"Command: {' '.join(command)}")
+                self.process = Popen(command)
+                self.get_logger().info("Mission started: " + target_mission)
+                self.mission_launched = True
+
+        elif (status.mission == State.MISSION_NONE or status.state == State.EMERGENCY) and self.mission_launched:
+            self.get_logger().warn("Closing mission")
+            self.process.terminate()
+            self.mission_launched = False
 
 
 def main(args=None):

--- a/src/operations/mission_controller/mission_controller/node_trackdrive_handler.py
+++ b/src/operations/mission_controller/mission_controller/node_trackdrive_handler.py
@@ -1,3 +1,4 @@
+from subprocess import Popen
 import time
 
 from tf2_ros import TransformException
@@ -8,18 +9,25 @@ import rclpy
 from rclpy.node import Node
 
 from driverless_msgs.msg import Shutdown, State
+from nav_msgs.msg import Odometry
 from std_msgs.msg import UInt8
+
+from std_srvs.srv import Trigger
 
 from driverless_common.shutdown_node import ShutdownNode
 
 
 class TrackdriveHandler(ShutdownNode):
     mission_started = False
+    odom_received = False
     crossed_start = False
     laps = 0
     last_lap_time = 0.0
     last_x = 0.0
     goal_offet = 5.0
+    process = None
+
+    sim = False
 
     def __init__(self):
         super().__init__("trackdrive_logic_node")
@@ -27,6 +35,17 @@ class TrackdriveHandler(ShutdownNode):
         self.declare_parameter("start_following", False)
 
         self.create_subscription(State, "system/as_status", self.state_callback, 1)
+        self.create_subscription(Odometry, "imu/odometry", self.odom_callback, 1)
+
+        if not self.sim:
+            # reset odom and pose from camera
+            self.reset_odom_client = self.create_client(Trigger, "zed2i/zed_node/reset_odometry")
+            self.reset_pose_client = self.create_client(Trigger, "zed2i/zed_node/reset_pos_tracking")
+
+            while not self.reset_odom_client.wait_for_service(timeout_sec=1.0):
+                self.get_logger().info("reset_odom_client service not available, waiting again...")
+            while not self.reset_pose_client.wait_for_service(timeout_sec=1.0):
+                self.get_logger().info("reset_pose_client service not available, waiting again...")
 
         self.create_timer((1 / 20), self.timer_callback)
         self.tf_buffer = Buffer()
@@ -45,11 +64,33 @@ class TrackdriveHandler(ShutdownNode):
 
     def state_callback(self, msg: State):
         super().state_callback(msg)
-        if not self.mission_started and msg.state == State.DRIVING and msg.mission == State.TRACKDRIVE:
+        if (
+            msg.state == State.DRIVING
+            and msg.mission == State.TRACKDRIVE
+            and msg.navigation_ready
+            and not self.mission_started
+            and self.odom_received
+        ):
             self.mission_started = True
             self.last_lap_time = time.time()
             self.lap_trig_pub.publish(UInt8(data=0))
+
+            if not self.sim:
+                # reset odom and pose from camera
+                self.reset_odom_client.call_async(Trigger.Request())
+                self.reset_pose_client.call_async(Trigger.Request())
+
+            command = ["stdbuf", "-o", "L", "ros2", "launch", "mission_controller", "trackdrive.launch.py"]
+            self.get_logger().info(f"Command: {' '.join(command)}")
+            self.process = Popen(command)
             self.get_logger().info("Trackdrive mission started")
+
+    def odom_callback(self, msg: Odometry):
+        """Ensure the SBG EKF has settled and we get odom msgs before starting the mission"""
+
+        if not self.odom_received:
+            self.odom_received = True
+            self.get_logger().info("Odometry received")
 
     def timer_callback(self):
         # check if car has crossed the finish line (0,0)
@@ -96,6 +137,10 @@ class TrackdriveHandler(ShutdownNode):
             # TODO: sort out vehicle states for eventual environment agnostic operation
             shutdown_msg = Shutdown(finished_engage_ebs=True)
             self.shutdown_pub.publish(shutdown_msg)
+
+            self.get_logger().warn("Closing Trackdrive mission")
+            self.process.terminate()
+            self.destroy_node()
 
 
 def main(args=None):

--- a/src/operations/mission_controller/package.xml
+++ b/src/operations/mission_controller/package.xml
@@ -13,10 +13,6 @@
     <depend>driverless_msgs</depend>
     <depend>lifecycle_msgs</depend>
     <!-- Custom packages -->
-    <depend>controllers</depend>
-    <depend>py_slam</depend>
-    <depend>path_follower</depend>
-    <depend>planners</depend>
     <depend>driverless_common</depend>
 
     <export>

--- a/src/operations/mission_controller/setup.py
+++ b/src/operations/mission_controller/setup.py
@@ -23,8 +23,8 @@ setup(
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
-            "mission_launcher = mission_controller.node_mission_launcher:main",
-            "inspection_handler = mission_controller.node_inspection_handler:main",
+            "mission_launcher_node = mission_controller.node_mission_launcher:main",
+            "inspection_handler_node = mission_controller.node_inspection_handler:main",
             "trackdrive_handler_node = mission_controller.node_trackdrive_handler:main",
             "trackdrive_handler_lifecycle = mission_controller.lifecycle_trackdrive_handler:main",
         ],


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide evidence of tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimisation

## [required] Description

Added a new state field to allow sensors time to boot up and settle before navigation programs begin. 
Includes steering centering before nav can start.

## [required] Documentation

Updated in: `Driverless/Documentation/Software/Infrastructure/Mission Launching`

### [optional] Usability concerns or breaking changes?

Navigation programs won't start until ready. Manually override with vehicle supervisor launch config to bring them into a driving state. (QUTMS_Driverless/src/machines/roscube_machine/launch/machine.launch.py, line 26)
