### PR TITLE
tools as bash scripts

### DIFF
--- a/installation/setup_standard.sh
+++ b/installation/setup_standard.sh
@@ -77,9 +77,9 @@ echo "---Building packages---"
 echo ""
 sleep 3
 cd ~/QUTMS
-colcon build --symlink-install --packages-up-to qutms_cli_tools
-# once the cli tools are built, we can use them to build the rest of the workspace
-ws_build --all
+
+# build the rest of the workspace
+source ~/QUTMS/build.sh
 
 ## Wrap up
 echo "Thank you for installing, explore the rest of the wiki"

--- a/installation/setup_standard.sh
+++ b/installation/setup_standard.sh
@@ -41,6 +41,12 @@ pip install -r ~/QUTMS/QUTMS_Driverless/installation/requirements.txt
 ## Create an alias for ease
 echo "alias a='source install/setup.bash'" >> ~/.bashrc
 
+ln -s ~/QUTMS/QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/build.sh ~/QUTMS/build.sh
+ln -s ~/QUTMS/QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/format.sh ~/QUTMS/format.sh
+ln -s ~/QUTMS/QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/launch.sh ~/QUTMS/launch.sh
+ln -s ~/QUTMS/QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/pull.sh ~/QUTMS/pull.sh
+ln -s ~/QUTMS/QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/record.sh ~/QUTMS/record.sh
+
 ## Check if user is going to work with vision
 source ~/QUTMS/QUTMS_Driverless/installation/install_scripts/install_torch_pip.sh
 

--- a/tools/qutms_cli_tools/qutms_cli_tools/build.py
+++ b/tools/qutms_cli_tools/qutms_cli_tools/build.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 import os
 import subprocess
 
-from qutms_cli_tools.common import Print
+# from common import Print
 import yaml
 
 
@@ -20,7 +20,9 @@ def main():
     ]
 
     # build packages listed as args
-    parser = ArgumentParser(description="Building selected packages. Must select a build group.")
+    parser = ArgumentParser(
+        description="Building selected packages. Must select a build group."
+    )
     parser.add_argument(
         "--select",
         "-s",
@@ -72,19 +74,20 @@ def main():
 
     elif args.up_to_package:
         command = command_prefix + ["--packages-up-to"] + args.up_to_package
-
     elif args.sim:
         command = command_prefix + ["--packages-up-to", "eufs_launcher"]
 
     elif args.all:
-        Print.blue("Ignoring packages from 'colcon_ignore.yaml':")
-        command = command_prefix + ["--packages-ignore"] + colcon_ignores["colcon_ignore"]
+        print("Ignoring packages from 'colcon_ignore.yaml':")
+        command = (
+            command_prefix + ["--packages-ignore"] + colcon_ignores["colcon_ignore"]
+        )
     else:
-        Print.red("Please specify a build group, use --help or -h for more info")
+        print("Please specify a build group, use --help or -h for more info")
         return
 
-    Print.green("Building packages...")
-    Print.blue(f"Command: {' '.join(command)}")
+    print("Building packages...")
+    print(f"Command: {' '.join(command)}")
     process = subprocess.Popen(command, text=True, cwd=ws_path)
     try:
         process.wait()
@@ -94,3 +97,7 @@ def main():
         except OSError:
             pass
         process.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/qutms_cli_tools/qutms_cli_tools/build.py
+++ b/tools/qutms_cli_tools/qutms_cli_tools/build.py
@@ -20,9 +20,7 @@ def main():
     ]
 
     # build packages listed as args
-    parser = ArgumentParser(
-        description="Building selected packages. Must select a build group."
-    )
+    parser = ArgumentParser(description="Building selected packages. Must select a build group.")
     parser.add_argument(
         "--select",
         "-s",
@@ -79,9 +77,7 @@ def main():
 
     elif args.all:
         print("Ignoring packages from 'colcon_ignore.yaml':")
-        command = (
-            command_prefix + ["--packages-ignore"] + colcon_ignores["colcon_ignore"]
-        )
+        command = command_prefix + ["--packages-ignore"] + colcon_ignores["colcon_ignore"]
     else:
         print("Please specify a build group, use --help or -h for more info")
         return

--- a/tools/qutms_cli_tools/qutms_cli_tools/build.sh
+++ b/tools/qutms_cli_tools/qutms_cli_tools/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/build.py "$@"

--- a/tools/qutms_cli_tools/qutms_cli_tools/format.py
+++ b/tools/qutms_cli_tools/qutms_cli_tools/format.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from qutms_cli_tools.common import Print
+from common import Print
 
 
 def format_repo(repo_path_relative):
@@ -34,3 +34,7 @@ def main():
             except OSError:
                 pass
             process.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/qutms_cli_tools/qutms_cli_tools/format.sh
+++ b/tools/qutms_cli_tools/qutms_cli_tools/format.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/format.py "$@"

--- a/tools/qutms_cli_tools/qutms_cli_tools/launch.py
+++ b/tools/qutms_cli_tools/qutms_cli_tools/launch.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 import subprocess
 
-from qutms_cli_tools.common import Print
+from common import Print
 
 
 def main():
@@ -32,3 +32,7 @@ def main():
         except OSError:
             pass
         process.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/qutms_cli_tools/qutms_cli_tools/launch.sh
+++ b/tools/qutms_cli_tools/qutms_cli_tools/launch.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/launch.py "$@"

--- a/tools/qutms_cli_tools/qutms_cli_tools/pull.py
+++ b/tools/qutms_cli_tools/qutms_cli_tools/pull.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 import os
 import subprocess
 
-from qutms_cli_tools.common import Print
+from common import Print
 
 
 def main():
@@ -40,3 +40,7 @@ def main():
         command = ["git", "pull"]
         process = subprocess.Popen(command, text=True, cwd=repo)
         process.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/qutms_cli_tools/qutms_cli_tools/pull.sh
+++ b/tools/qutms_cli_tools/qutms_cli_tools/pull.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/pull.py "$@"

--- a/tools/qutms_cli_tools/qutms_cli_tools/record.py
+++ b/tools/qutms_cli_tools/qutms_cli_tools/record.py
@@ -2,8 +2,9 @@ from argparse import ArgumentParser
 import os
 import subprocess
 
-from qutms_cli_tools.common import Print
 import yaml
+
+from common import Print
 
 
 def main():
@@ -54,7 +55,13 @@ def main():
 
     Print.green("Recording bag...")
 
-    config_path = os.path.join(ws_path, "QUTMS_Driverless", "tools", "topics_to_record", str(args.yaml) + ".yaml")
+    config_path = os.path.join(
+        ws_path,
+        "QUTMS_Driverless",
+        "tools",
+        "topics_to_record",
+        str(args.yaml) + ".yaml",
+    )
 
     with open(config_path, "r") as f:
         topics = yaml.safe_load(f)
@@ -85,3 +92,7 @@ def main():
         except OSError:
             pass
         process.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/qutms_cli_tools/qutms_cli_tools/record.sh
+++ b/tools/qutms_cli_tools/qutms_cli_tools/record.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 QUTMS_Driverless/tools/qutms_cli_tools/qutms_cli_tools/record.py "$@"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide evidence of tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimisation

## [required] Description

In qutms_cli_tools created bash files to call the python scripts (i.e. build.py) in the command line interface. Symlinks (shortcuts) were created of those bash scripts. Arguments are forwarded from bash to python.

## [required] Documentation

https://docs.google.com/document/d/1MmFTtyRppXqyWelj_COYUsaF81bytKuAtvTLVzLHFzM/edit?usp=sharing

https://qut-motorsports.notion.site/Calling-a-Python-File-Through-a-Bash-Script-CLI-shortcut-scripts-8ac3c4e9d6644870b625ec28959f8042

### [optional] Usability concerns or breaking changes?

please note: local python imports - do not work with colcon anymore (you must use the symmlinks/shortcuts) 

Ensure Colorama is installed by pip colorama in WSL. 